### PR TITLE
Update Axis components to allow tick count to be an input

### DIFF
--- a/src/common/axes/x-axis.component.ts
+++ b/src/common/axes/x-axis.component.ts
@@ -50,10 +50,10 @@ export class XAxisComponent implements OnChanges {
   @Input() showLabel;
   @Input() labelText;
   @Input() xAxisTickInterval;
+  @Input() xAxisTickCount: any;
 
   @Output() dimensionsChanged = new EventEmitter();
 
-  xAxisTickCount: any;
   xAxisClassName: string = 'x axis';
   xOrient: string = 'bottom';
   tickArguments: any;

--- a/src/common/axes/y-axis.component.ts
+++ b/src/common/axes/y-axis.component.ts
@@ -49,11 +49,10 @@ export class YAxisComponent implements OnChanges {
   @Input() showLabel;
   @Input() labelText;
   @Input() yAxisTickInterval;
-
+  @Input() yAxisTickCount: any;
   @Output() dimensionsChanged = new EventEmitter();
 
   yAxisClassName: string = 'y axis';
-  yAxisTickCount: any;
   tickArguments: any;
   offset: any;
   transform: any;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x ] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Users are unable to specify the tick count for the axis.

**What is the new behavior?**
Users are able to supply the tick count for axis via an Input.

**Does this PR introduce a breaking change?** (check one with "x")
- [ x ] No