### PR TITLE
Only modify the chart width based on columns when showLegend is enabled

### DIFF
--- a/src/common/view-dimensions.helper.ts
+++ b/src/common/view-dimensions.helper.ts
@@ -18,9 +18,8 @@ export function calculateViewDimensions({
     } else {
       columns -= 1;
     }
+    chartWidth = chartWidth * columns / 12;
   }
-
-  chartWidth = chartWidth * columns / 12;
 
   chartWidth = chartWidth - margins[1] - margins[3];
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x ] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

In the 2.x to 3.x upgrade we started defaulting the chart width to always be modified by columns.
Previously we only modified based on columns if showLegend was set. The result of this was a chart that was always shifted to the side due and smaller than the set view width.

**What is the new behavior?**
The new behavior is to only modify the chartWidth based on columns if showLegend is enabled.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x ] No