### PR TITLE
Only include used Rxjs operators to decrease file size

### DIFF
--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -12,7 +12,9 @@ import {
   SimpleChanges
 } from '@angular/core';
 import { Location } from '@angular/common';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/debounceTime';
 
 @Component({
   selector: 'base-chart',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Includes all of RxJS even-though only a small fraction of it was used.


**What is the new behavior?**
Only the parts of RxJS that are actually used will be included in the production bundle.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
Relates to #131

I'm aware that this was attempted before in #116 which ended up being reverted due to problems mentioned in #119. The issue shouldn't occur this time around though since the operators/observable is imported in `base-chart.component.ts`, where it's actually used, as opposed to previous attempt where they were imported in `chart-common.module.ts` which I think caused the issue as the custom-chart directly imported the the base-chart component, and thus did not get the required RxJS imports.