### PR TITLE
feat(bubble): show axis labels in tooltip

### DIFF
--- a/src/bubble-chart/bubble-chart.component.ts
+++ b/src/bubble-chart/bubble-chart.component.ts
@@ -72,6 +72,8 @@ import { ColorHelper } from '../common/color.helper';
             [rScale]="rScale"
             [xScaleType]="xScaleType"
             [yScaleType]="yScaleType"
+            [xAxisLabel]="xAxisLabel"
+            [yAxisLabel]="yAxisLabel"
             [colors]="colors"
             [data]="series"
             [activeEntries]="activeEntries"

--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -63,6 +63,8 @@ export class BubbleSeriesComponent implements OnChanges {
   @Input() colors;
   @Input() visibleValue;
   @Input() activeEntries: any[];
+  @Input() xAxisLabel: string;
+  @Input() yAxisLabel: string;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -129,7 +131,8 @@ export class BubbleSeriesComponent implements OnChanges {
         ${circle.seriesName} • ${circle.tooltipLabel}
       </span>
       <span class="tooltip-label">
-        ${circle.x.toLocaleString()} ${circle.y.toLocaleString()}
+        <span>${this.xAxisLabel}: ${circle.x.toLocaleString()}</span><br />
+        <span>${this.yAxisLabel}: ${circle.y.toLocaleString()}</span>
       </span>
       <span class="tooltip-val">
         ${radiusValue}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Feature

**What is the current behavior?** (You can also link to an open issue here)
Values in bubble tool-tip are cryptic.


**What is the new behavior?**
Add x and y axis labels to tooltips.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:

We may want to an an ngIf on each value.  Either on the xAxisLabel or showXAxisLabel.