### PR TITLE
feat(gauge): option to override displayValue

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -367,6 +367,7 @@
         [view]="view"
         [legend]="showLegend"
         [results]="single"
+        [textValue]="gaugeTextValue"
         [scheme]="colorScheme"
         [min]="gaugeMin"
         [max]="gaugeMax"

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -86,6 +86,7 @@ export class AppComponent implements OnInit {
   gaugeMax: number = 100;
   gaugeLargeSegments: number = 10;
   gaugeSmallSegments: number = 5;
+  gaugeTextValue: string = '';
   gaugeUnits: string = 'alerts';
   gaugeAngleSpan: number = 240;
   gaugeStartAngle: number = -120;

--- a/src/gauge/gauge.component.ts
+++ b/src/gauge/gauge.component.ts
@@ -76,6 +76,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
   @Input() legend = false;
   @Input() min: number = 0;
   @Input() max: number = 100;
+  @Input() textValue: string;
   @Input() units: string;
   @Input() bigSegments: number = 10;
   @Input() smallSegments: number = 5;
@@ -246,6 +247,10 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
 
   getDisplayValue(): string {
     const value = this.results.map(d => d.value).reduce((a, b) => a + b, 0);
+
+    if(this.textValue && 0 !== this.textValue.length) {
+      return this.textValue.toLocaleString();
+    }
     return value.toLocaleString();
   }
 


### PR DESCRIPTION
Option to override displayValue with custom textValue

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The display value in the Gauge automatically defaults to the results value (input).


**What is the new behavior?**
Option to override the displayValue with a custom textValue. I would like the flexibility to display a value not equal to the default single value or the sum of the values in the series.

Example: 
- Min value = 0
- Max value = 100
- Arc 1 = Actual = 250
- Arc 2 = Target = 300
- Display Value = 250 .. not 550

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
