### PR TITLE
fix(bubble): Hide axis labels in tooltips when none are given

### DIFF
--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -126,13 +126,15 @@ export class BubbleSeriesComponent implements OnChanges {
   getTooltipText(circle): string {
     const hasRadius = typeof circle.r !== 'undefined';
     const radiusValue = hasRadius ? circle.r.toLocaleString() : '';
+    const xAxisLabel = this.xAxisLabel && this.xAxisLabel !== '' ? `${this.xAxisLabel}:` : '';
+    const yAxisLabel = this.yAxisLabel && this.yAxisLabel !== '' ? `${this.yAxisLabel}:` : '';
     return `
       <span class="tooltip-label">
         ${circle.seriesName} • ${circle.tooltipLabel}
       </span>
       <span class="tooltip-label">
-        <span>${this.xAxisLabel}: ${circle.x.toLocaleString()}</span><br />
-        <span>${this.yAxisLabel}: ${circle.y.toLocaleString()}</span>
+        <label>${xAxisLabel}</label> ${circle.x.toLocaleString()}<br />
+        <label>${yAxisLabel}</label> ${circle.y.toLocaleString()}
       </span>
       <span class="tooltip-val">
         ${radiusValue}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Axis labels in tooltips when are shown as `:` when no label is passed.


**What is the new behavior?**
Hide axis labels in tooltips when none are given


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No