### PR TITLE
Fix padding on bubble charts

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -245,7 +245,9 @@
         [autoScale]="autoScale"
         [scheme]="colorScheme"
         [schemeType]="schemeType"
-        [roundDomains]="roundDomains">
+        [roundDomains]="roundDomains"
+        [minRadius]="minRadius"
+        [maxRadius]="maxRadius">
       </ngx-charts-bubble-chart>
       <ngx-charts-force-directed-graph
         *ngIf="chartType === 'force-directed-graph'"
@@ -693,6 +695,15 @@
         <label>Bottom:</label><input type="number" [(ngModel)]="marginBottom"><br />
         <label>Left:</label><input type="number" [(ngModel)]="marginLeft"><br />
       </div>
+
+      <div *ngIf="chart.options.includes('minRadius')">
+        <label>Maximum Radius:</label><input type="number" [(ngModel)]="minRadius">
+      </div>
+
+      <div *ngIf="chart.options.includes('maxRadius')">
+        <label>Maximum Radius:</label><input type="number" [(ngModel)]="maxRadius">
+      </div>
+
     </div>
     <h3><a href="https://swimlane.gitbooks.io/ngx-charts/content/" target="_blank">Documentation</a></h3>
     </div>

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -49,6 +49,8 @@ export class AppComponent implements OnInit {
   barPadding = 8;
   groupPadding = 16;
   roundDomains = false;
+  maxRadius = 10;
+  minRadius = 3;
 
   // line interpolation
   curveType: string = 'Linear';

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -169,7 +169,7 @@ const chartGroups = [
         options: [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'showLegend',
           'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel', 'showGridLines',
-          'roundDomains', 'autoScale'
+          'roundDomains', 'autoScale', 'minRadius', 'maxRadius'
         ]
       },
       {

--- a/src/bubble-chart/bubble-chart.utils.ts
+++ b/src/bubble-chart/bubble-chart.utils.ts
@@ -49,7 +49,7 @@ export function getDomain(values, scaleType, autoScale): number[] {
     return domain;
 }
 
-export function getScale(domain, range: number[], scaleType, padding, roundDomains): any {
+export function getScale(domain, range: number[], scaleType, roundDomains): any {
   let scale: any;
 
   if (scaleType === 'time') {
@@ -59,7 +59,7 @@ export function getScale(domain, range: number[], scaleType, padding, roundDomai
   } else if (scaleType === 'linear') {
     scale = d3.scaleLinear()
       .range(range)
-      .domain([domain[0] - padding, domain[1] + padding]);
+      .domain(domain);
 
     if (roundDomains) {
       scale = scale.nice();
@@ -67,7 +67,6 @@ export function getScale(domain, range: number[], scaleType, padding, roundDomai
   } else if (scaleType === 'ordinal') {
     scale = d3.scalePoint()
       .range(range)
-      .padding(0.1)
       .domain(domain);
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Padding was not added to bubble chart when the scale is ordinal.
Padding was too generous.


**What is the new behavior?**
Padding was now added to bubble chart with ordinal scales.
Padding was too greedy on each side.


**Does this PR introduce a breaking change?** (check one with "x")
No

