### PR TITLE
fix(build): Lock jasmine typings to avoid errors during build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/d3-selection": "0.0.3",
     "@types/d3-shape": "0.0.4",
     "@types/d3-time-format": "2.0.4",
-    "@types/jasmine": "^2.5.41",
+    "@types/jasmine": "2.5.41",
     "angular2-template-loader": "^0.6.0",
     "autoprefixer": "^6.7.0",
     "awesome-typescript-loader": "~3.0.0-beta.10",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When installing package dependencies with `npm install`, newer jasmine typings are installed which cause the following errors during `npm run build`:

> ERROR in [at-loader] node_modules\@types\jasmine\index.d.ts:39:52
>     TS1005: '=' expected.
> 
> ERROR in [at-loader] node_modules\@types\jasmine\index.d.ts:39:38
>     TS2371: A parameter initializer is only allowed in a function or constructor implementation.
> 
> ERROR in [at-loader] node_modules\@types\jasmine\index.d.ts:39:46
>     TS2304: Cannot find name 'keyof'.

**What is the new behavior?**

Typings are locked to version 2.5.41 which do not have this bug.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
