### PR TITLE
fix(charts): Only prepend pathUrl when PathLocationStrategy is used.

### DIFF
--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 
 import d3 from '../d3';
+import { PathLocationStrategy } from '@angular/common';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
@@ -269,7 +270,11 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
       this.legendOptions = this.getLegendOptions();
 
       this.transform = `translate(${ this.dims.xOffset } , ${ this.margin[0] })`;
-      const pageUrl = this.location.path();
+
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.clipPathId = 'clip' + id().toString();
       this.clipPath = `url(${pageUrl}#${this.clipPathId})`;
     });

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -7,6 +7,7 @@ import {
   HostListener,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { PathLocationStrategy } from '@angular/common';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
@@ -242,7 +243,11 @@ export class AreaChartStackedComponent extends BaseChartComponent {
       this.legendOptions = this.getLegendOptions();
 
       this.transform = `translate(${ this.dims.xOffset } , ${ this.margin[0] })`;
-      const pageUrl = this.location.path();
+
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.clipPathId = 'clip' + id().toString();
       this.clipPath = `url(${pageUrl}#${this.clipPathId})`;
     });

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -7,6 +7,7 @@ import {
   HostListener,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { PathLocationStrategy } from '@angular/common';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
@@ -211,7 +212,11 @@ export class AreaChartComponent extends BaseChartComponent {
       this.legendOptions = this.getLegendOptions();
 
       this.transform = `translate(${ this.dims.xOffset }, ${ this.margin[0] })`;
-      const pageUrl = this.location.path();
+
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.clipPathId = 'clip' + id().toString();
       this.clipPath = `url(${pageUrl}#${this.clipPathId})`;
     });

--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -9,7 +9,7 @@ import {
   OnChanges,
   ChangeDetectionStrategy
  } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { id } from '../utils/id';
 import d3 from '../d3';
 
@@ -63,7 +63,7 @@ export class BarComponent implements OnChanges {
   gradientStops: any[];
   hasGradient: boolean = false;
 
-  constructor(element: ElementRef, private location: Location) {
+  constructor(element: ElementRef, private location: LocationStrategy) {
     this.element = element.nativeElement;
   }
 
@@ -77,7 +77,10 @@ export class BarComponent implements OnChanges {
   }
 
   update(): void {
-    const pageUrl = this.location.path();
+    const pageUrl = this.location instanceof PathLocationStrategy
+      ? this.location.path()
+      : '';
+
     this.gradientId = 'grad' + id().toString();
     this.gradientFill = `url(${pageUrl}#${this.gradientId})`;
 

--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -11,7 +11,6 @@ import {
   transition,
   animate
 } from '@angular/core';
-import { Location } from '@angular/common';
 import { formatLabel } from '../common/label.helper';
 import { id } from '../utils/id';
 

--- a/src/common/area.component.ts
+++ b/src/common/area.component.ts
@@ -8,7 +8,7 @@ import {
   OnChanges,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { id } from '../utils/id';
 import d3 from '../d3';
 
@@ -55,7 +55,7 @@ export class AreaComponent implements OnChanges {
   gradientStops: any[];
   hasGradient: boolean = false;
 
-  constructor(element: ElementRef, private location: Location) {
+  constructor(element: ElementRef, private location: LocationStrategy) {
     this.element = element.nativeElement;
   }
 
@@ -69,7 +69,10 @@ export class AreaComponent implements OnChanges {
   }
 
   update(): void {
-    const pageUrl = this.location.path();
+    const pageUrl = this.location instanceof PathLocationStrategy
+      ? this.location.path()
+      : '';
+
     this.gradientId = 'grad' + id().toString();
     this.gradientFill = `url(${pageUrl}#${this.gradientId})`;
 
@@ -99,7 +102,7 @@ export class AreaComponent implements OnChanges {
     if (this.stops) {
       return this.stops;
     }
-    
+
     return [
       {
         offset: 0,

--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -3,7 +3,7 @@ import {
   Output, EventEmitter, AfterViewInit, OnDestroy, OnChanges, SimpleChanges
 } from '@angular/core';
 
-import { Location } from '@angular/common';
+import { LocationStrategy } from '@angular/common';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/debounceTime';
@@ -32,7 +32,7 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
     protected chartElement: ElementRef,
     protected zone: NgZone,
     protected cd: ChangeDetectorRef,
-    protected location: Location) {
+    protected location: LocationStrategy) {
   }
 
   ngAfterViewInit(): void {
@@ -95,7 +95,7 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
     if (width && height) {
       return { width, height };
     }
-    
+
     return null;
   }
 

--- a/src/common/circle-series.component.ts
+++ b/src/common/circle-series.component.ts
@@ -11,7 +11,7 @@ import {
   transition,
   animate
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { formatLabel } from '../common/label.helper';
 import { id } from '../utils/id';
 
@@ -88,7 +88,7 @@ export class CircleSeriesComponent implements OnChanges {
   areaPath: any;
   circles: any[];
 
-  constructor(private location: Location) {
+  constructor(private location: LocationStrategy) {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -101,7 +101,10 @@ export class CircleSeriesComponent implements OnChanges {
 
   getCircles(): any[] {
     const seriesName = this.data.name;
-    const pageUrl = this.location.path();
+
+    const pageUrl = this.location instanceof PathLocationStrategy
+      ? this.location.path()
+      : '';
 
     return this.data.series.map((d, i) => {
       const value = d.value;

--- a/src/common/timeline/timeline.component.ts
+++ b/src/common/timeline/timeline.component.ts
@@ -3,7 +3,7 @@ import {
   OnChanges, ChangeDetectionStrategy, NgZone,
   ChangeDetectorRef, SimpleChanges, ViewEncapsulation
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import d3 from '../../d3';
 import { id } from '../../utils';
 
@@ -60,8 +60,12 @@ export class Timeline implements OnChanges {
   filterId: any;
   filter: any;
 
-  constructor(element: ElementRef, private zone: NgZone, private cd: ChangeDetectorRef, private location: Location) {
-    this.element = element.nativeElement;
+  constructor(
+    element: ElementRef,
+    private zone: NgZone,
+    private cd: ChangeDetectorRef,
+    private location: LocationStrategy) {
+      this.element = element.nativeElement;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -88,7 +92,10 @@ export class Timeline implements OnChanges {
 
       this.transform = `translate(0 , ${ offsetY })`;
 
-      const pageUrl = this.location.path();
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.filterId = 'filter' + id().toString();
       this.filter = `url(${pageUrl}#${this.filterId})`;
 

--- a/src/heat-map/heat-map-cell.component.ts
+++ b/src/heat-map/heat-map-cell.component.ts
@@ -8,7 +8,7 @@ import {
   OnChanges,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { id } from '../utils/id';
 import d3 from '../d3';
 
@@ -58,13 +58,16 @@ export class HeatMapCellComponent implements OnChanges {
   gradientUrl: string;
   gradientStops: any[];
 
-  constructor(element: ElementRef, private location: Location) {
+  constructor(element: ElementRef, private location: LocationStrategy) {
     this.element = element.nativeElement;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     this.transform = `translate(${this.x} , ${this.y})`;
-    const pageUrl = this.location.path();
+
+    const pageUrl = this.location instanceof PathLocationStrategy
+      ? this.location.path()
+      : '';
 
     this.startOpacity = 0.3;
     this.gradientId = 'grad' + id().toString();

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -7,6 +7,7 @@ import {
   HostListener,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { PathLocationStrategy } from '@angular/common';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
@@ -211,7 +212,11 @@ export class LineChartComponent extends BaseChartComponent {
       this.legendOptions = this.getLegendOptions();
 
       this.transform = `translate(${ this.dims.xOffset } , ${ this.margin[0] })`;
-      const pageUrl = this.location.path();
+
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.clipPathId = 'clip' + id().toString();
       this.clipPath = `url(${pageUrl}#${this.clipPathId})`;
     });

--- a/src/line-chart/line-series.component.ts
+++ b/src/line-chart/line-series.component.ts
@@ -5,7 +5,7 @@ import {
   SimpleChanges,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import d3 from '../d3';
 import { id } from '../utils/id';
 import { sortLinear, sortByTime, sortByDomain } from '../utils/sort';
@@ -75,7 +75,7 @@ export class LineSeriesComponent implements OnChanges {
   gradientStops: any[];
   areaGradientStops: any[];
 
-  constructor(private location: Location) {
+  constructor(private location: LocationStrategy) {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -161,7 +161,11 @@ export class LineSeriesComponent implements OnChanges {
   updateGradients() {
     if (this.colors.scaleType === 'linear') {
       this.hasGradient = true;
-      const pageUrl = this.location.path();
+
+      const pageUrl = this.location instanceof PathLocationStrategy
+        ? this.location.path()
+        : '';
+
       this.gradientId = 'grad' + id().toString();
       this.gradientUrl = `url(${pageUrl}#${this.gradientId})`;
       const values = this.data.series.map(d => d.value);

--- a/src/pie-chart/pie-arc.component.ts
+++ b/src/pie-chart/pie-arc.component.ts
@@ -8,7 +8,7 @@ import {
   OnChanges,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { Location } from '@angular/common';
+import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import d3 from '../d3';
 import { id } from '../utils/id';
 
@@ -67,7 +67,7 @@ export class PieArcComponent implements OnChanges {
   gradientFill: string;
   initialized: boolean = false;
 
-  constructor(element: ElementRef, private location: Location) {
+  constructor(element: ElementRef, private location: LocationStrategy) {
     this.element = element.nativeElement;
   }
 
@@ -80,9 +80,11 @@ export class PieArcComponent implements OnChanges {
     this.path = arc.startAngle(this.startAngle).endAngle(this.endAngle)();
     this.startOpacity = 0.5;
 
-    const pageUrl = this.location.path();
-    this.radialGradientId = 'linearGrad' + id().toString();
+    const pageUrl = this.location instanceof PathLocationStrategy
+      ? this.location.path()
+      : '';
 
+    this.radialGradientId = 'linearGrad' + id().toString();
     this.gradientFill = `url(${pageUrl}#${this.radialGradientId})`;
 
     if (this.animate) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Gradients don't work when HashLocationStrategy is used.

**What is the new behavior?**

Fixes: #238 

`Location` references have been replaced with `LocationStrategy`. This is required for the `instanceof` check against `PathLocationStrategy`. Since `LocationStrategy` has a working `path()` method as well, there should be no problems using it instead of `Location`.

This PR makes sure that `pageUrl` is the current `location.path()` if `PathLocationStrategy` is being used, otherwise it will be an empty string.

Changes tested with Chrome v56 and Firefox v51.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
