### PR TITLE
fix(AOT): Mark optional parameters in onClick functions.

### DIFF
--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -405,7 +405,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
     this.deactivateAll();
   }
 
-  onClick(data, series): void {
+  onClick(data, series?): void {
     if (series) {
       data.series = series.name;
     }

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -403,7 +403,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
     this.deactivateAll();
   }
 
-  onClick(data, series): void {
+  onClick(data, series?): void {
     if (series) {
       data.series = series.name;
     }

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -361,10 +361,11 @@ export class AreaChartComponent extends BaseChartComponent {
     this.deactivateAll();
   }
 
-  onClick(data, series): void {
+  onClick(data, series?): void {
     if (series) {
       data.series = series.name;
     }
+
     this.select.emit(data);
   }
 

--- a/src/bar-chart/bar-horizontal-2d.component.ts
+++ b/src/bar-chart/bar-horizontal-2d.component.ts
@@ -184,7 +184,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
     const scale = d3.scaleLinear()
       .range([0, this.dims.width])
       .domain(this.valuesDomain);
-    
+
     return this.roundDomains ? scale.nice() : scale;
   }
 
@@ -235,7 +235,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
     return `translate(0, ${this.groupScale(group.name)})`;
   }
 
-  onClick(data, group): void {
+  onClick(data, group?): void {
     if (group) {
       data.series = group.name;
     }

--- a/src/bar-chart/bar-horizontal-normalized.component.ts
+++ b/src/bar-chart/bar-horizontal-normalized.component.ts
@@ -201,7 +201,7 @@ export class BarHorizontalNormalizedComponent extends BaseChartComponent {
     return `translate(0, ${this.yScale(group.name)})`;
   }
 
-  onClick(data, group): void {
+  onClick(data, group?): void {
     if (group) {
       data.series = group.name;
     }

--- a/src/bar-chart/bar-horizontal-stacked.component.ts
+++ b/src/bar-chart/bar-horizontal-stacked.component.ts
@@ -215,7 +215,7 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
     return `translate(0, ${this.yScale(group.name)})`;
   }
 
-  onClick(data, group): void {
+  onClick(data, group?): void {
     if (group) {
       data.series = group.name;
     }

--- a/src/bar-chart/bar-vertical-2d.component.ts
+++ b/src/bar-chart/bar-vertical-2d.component.ts
@@ -161,7 +161,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
 
   getGroupScale() {
     const spacing = this.groupDomain.length / (this.dims.height / this.groupPadding + 1);
-  
+
     return d3.scaleBand()
       .rangeRound([0, this.dims.width])
       .paddingInner(spacing)
@@ -228,10 +228,11 @@ export class BarVertical2DComponent extends BaseChartComponent {
     return `translate(${this.groupScale(group.name)}, 0)`;
   }
 
-  onClick(data, group) {
+  onClick(data, group?) {
     if (group) {
       data.series = group.name;
     }
+
     this.select.emit(data);
   }
 

--- a/src/bar-chart/bar-vertical-normalized.component.ts
+++ b/src/bar-chart/bar-vertical-normalized.component.ts
@@ -199,10 +199,11 @@ export class BarVerticalNormalizedComponent extends BaseChartComponent {
     return `translate(${this.xScale(group.name)}, 0)`;
   }
 
-  onClick(data, group) {
+  onClick(data, group?) {
     if (group) {
       data.series = group.name;
     }
+
     this.select.emit(data);
   }
 

--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -211,10 +211,11 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
     return `translate(${this.xScale(group.name)}, 0)`;
   }
 
-  onClick(data, group) {
+  onClick(data, group?) {
     if (group) {
       data.series = group.name;
     }
+
     this.select.emit(data);
   }
 

--- a/src/bubble-chart/bubble-chart.component.ts
+++ b/src/bubble-chart/bubble-chart.component.ts
@@ -173,10 +173,11 @@ export class BubbleChartComponent extends BaseChartComponent {
     this.deactivateAll();
   }
 
-  onClick(data, series): void {
+  onClick(data, series?): void {
     if (series) {
       data.series = series.name;
     }
+
     this.select.emit(data);
   }
 

--- a/src/force-directed-graph/force-directed-graph.component.ts
+++ b/src/force-directed-graph/force-directed-graph.component.ts
@@ -132,7 +132,7 @@ export class ForceDirectedGraphComponent extends BaseChartComponent {
     });
   }
 
-  onClick(data, node): void {
+  onClick(data): void {
     this.select.emit(data);
   }
 

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -370,10 +370,11 @@ export class LineChartComponent extends BaseChartComponent {
     this.deactivateAll();
   }
 
-  onClick(data, series): void {
+  onClick(data, series?): void {
     if (series) {
       data.series = series.name;
     }
+
     this.select.emit(data);
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`legendLabelClick` calls `onClick` with just one parameter, causing AoT compilation to fail.

The `onClick` functions do actually check if the 2nd parameter is given, so it's clear that the 2nd parameter is intended to be optional.

**What is the new behavior?**

Fixes: #232

Optional parameters in `onClick` functions have been marked with a questionmark (`?`) to show that they can be omitted. Typescript will then happily compile AOT again.

This PR should fix AOT errors with all chart types. We currently only tested line and bar charts, but we assume that it should work with the others just as fine, since the `onClick` function calls are the same on every other chart component.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

We would be glad if this PR could get a priority review / release cycle 😄 