### PR TITLE
fix(rollup): Set tsconfig-aot module to 'es2015'.

### DIFF
--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
     "noEmitHelpers": false,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When running rollup to minify code, rollup throws a bunch of 'x is not exported by ...' errors.

**What is the new behavior?**

Rollup works.

This PR changes the tsconfig-aot module setting from `commonjs` to `es2015`. This change is required, otherwise rollup is not able to detect the modules.

Quote from the [Angular 2 AOT Cookbook](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html#!#tree-shaking):

> Rollup can only Tree Shake ES2015 modules which have import and export statements.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:

In order for rollup to successfully work, the modules need to be referenced directly in import statements as of now. Even though the current `index.ts` in the release folder references all modules, rollup still ends up not resolving the exports for some reason.

Use an import statement like this:
`import { NgxChartsModule } from '@swimlane/ngx-charts/release/ngx-charts.module';`

or import your chart directly, e. g.:
`import { LineChartModule } from '@swimlane/ngx-charts/release/line-chart/line-chart.module';`

That way rollup works.