### PR TITLE
fix(packaging): limit package contents to release directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "Olivier Combe"
   ],
   "license": "MIT",
+  "files": [
+    "release"
+  ],
   "bugs": {
     "url": "https://github.com/swimlane/ngx-charts/issues"
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Other... Please describe:
reduces the files installed by the package

**What is the current behavior?** (You can also link to an open issue here)

A large amount of unneeded files are installed with the package

**What is the new behavior?**

Only the `release` directory, `package.json`, and the `README` are now included.  Note that the last two are included by default.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 

The full source as well as build configuration files were previously present.  Some users may have incorrectly referenced these files.  Only the `release` files should be used from within the package.


**Other information**:
