### PR TITLE
fix: synchronize and unpin the d3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "peerDependencies": {
     "@angular/common": "~2.4.5",
     "@angular/core": "~2.4.5",
-    "d3": "4.4.0",
+    "d3": "^4.4.0",
     "rxjs": "^5.0.3"
   },
   "devDependencies": {
@@ -112,7 +112,7 @@
     "cpx": "^1.5.0",
     "cross-env": "^3.1.4",
     "css-loader": "^0.26.1",
-    "d3": "4.2.2",
+    "d3": "^4.4.0",
     "extract-text-webpack-plugin": "2.0.0-beta.4",
     "file-loader": "^0.9.0",
     "fs-extra": "^2.0.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

The peer and development dependency versions of d3 are mismatched.  This results in an npm warning during development.

**What is the new behavior?**

The peer and development versions are synchronized.  The version is also unpinned as d3 appears to follow a semver approach to its API.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
