### PR TITLE
test: replace use of d3 selection api

### DIFF
--- a/src/bar-chart/bar-horizontal.component.spec.ts
+++ b/src/bar-chart/bar-horizontal.component.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import d3 from '../d3';
+import { By } from '@angular/platform-browser';
+
 import '../../config/testing-utils';
 import { single } from '../../demo/data';
 import { APP_BASE_HREF } from '@angular/common';
 
 import { BarChartModule } from './bar-chart.module';
+import { BarComponent } from './bar.component'; 
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
@@ -52,11 +54,11 @@ describe('<ngx-charts-bar-horizontal>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        expect(svg.attr('width')).toEqual('400');
-        expect(svg.attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
+
         done();
       });
     });
@@ -78,11 +80,9 @@ describe('<ngx-charts-bar-horizontal>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-height')).toEqual('123'); // ~(780 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.height).toEqual(123); // ~(780 - 5 * barPadding) / 6 
         done();
       });
     });
@@ -107,11 +107,9 @@ describe('<ngx-charts-bar-horizontal>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-height')).toEqual('130'); // ~(780 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.height).toEqual(130); // ~(780 - 5 * barPadding) / 6 
         done();
       });
     });
@@ -133,11 +131,9 @@ describe('<ngx-charts-bar-horizontal>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-height')).toEqual('113'); // ~(780 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.height).toEqual(113); // ~(780 - 5 * barPadding) / 6 
         done();
       });
     });

--- a/src/bar-chart/bar-vertical.component.spec.ts
+++ b/src/bar-chart/bar-vertical.component.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import d3 from '../d3';
+import { By } from '@angular/platform-browser';
+
 import '../../config/testing-utils';
 import { single } from '../../demo/data';
 import { APP_BASE_HREF } from '@angular/common';
 
 import { BarChartModule } from './bar-chart.module';
+import { BarComponent } from './bar.component'; 
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
@@ -52,11 +54,10 @@ describe('<ngx-charts-bar-vertical>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        expect(svg.attr('width')).toEqual('400');
-        expect(svg.attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
         done();
       });
     });
@@ -78,11 +79,9 @@ describe('<ngx-charts-bar-vertical>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-width')).toEqual('53'); // ~(360 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.width).toEqual(53); // ~(360 - 5 * barPadding) / 6 
         done();
       });
     });
@@ -107,11 +106,9 @@ describe('<ngx-charts-bar-vertical>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-width')).toEqual('60'); // ~(360 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.width).toEqual(60); // ~(360 - 5 * barPadding) / 6 
         done();
       });
     });
@@ -133,11 +130,9 @@ describe('<ngx-charts-bar-vertical>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const bars = compiled.querySelectorAll('[ngx-charts-bar]');
-        const bar = d3.select(bars[0]);
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
 
-        expect(bar.attr('ng-reflect-width')).toEqual('43'); // ~(360 - 5 * barPadding) / 6 
+        expect(bar.componentInstance.width).toEqual(43); // ~(360 - 5 * barPadding) / 6 
         done();
       });
     });

--- a/src/bubble-chart/bubble-chart.component.spec.ts
+++ b/src/bubble-chart/bubble-chart.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import d3 from '../d3';
+
 import '../../config/testing-utils';
 import { bubble } from '../../demo/data';
 import { APP_BASE_HREF } from '@angular/common';
@@ -51,11 +51,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        expect(svg.attr('width')).toEqual('400');
-        expect(svg.attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
         done();
       });
     });

--- a/src/common/charts/chart.component.spec.ts
+++ b/src/common/charts/chart.component.spec.ts
@@ -3,7 +3,7 @@ import {
   async
 } from '@angular/core/testing';
 import { Component  } from '@angular/core';
-import d3 from '../../d3';
+
 import '../../../config/testing-utils';
 
 import { ChartCommonModule } from '../chart-common.module';
@@ -48,11 +48,10 @@ describe('<ngx-charts-chart>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        const svg = compiled.querySelectorAll('svg')[0];
-        expect(d3.select(svg).attr('width')).toEqual('400');
-        expect(d3.select(svg).attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
       });
     }));
 
@@ -61,12 +60,9 @@ describe('<ngx-charts-chart>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
+        const textNode = fixture.debugElement.nativeElement.querySelector('svg p');
 
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
-
-        const textNode = svg.select('p');
-        expect(textNode.text()).toEqual('ngx-charts is cool!');
+        expect(textNode.textContent).toEqual('ngx-charts is cool!');
 
       });
     }));

--- a/src/common/legend/legend.component.spec.ts
+++ b/src/common/legend/legend.component.spec.ts
@@ -3,7 +3,7 @@ import {
   async
 } from '@angular/core/testing';
 import { Component  } from '@angular/core';
-import d3 from '../../d3';
+
 import '../../../config/testing-utils';
 
 import { ChartCommonModule } from '../chart-common.module';

--- a/src/heat-map/heat-map.component.spec.ts
+++ b/src/heat-map/heat-map.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import d3 from '../d3';
+
 import '../../config/testing-utils';
 import { multi } from '../../demo/data';
 import {APP_BASE_HREF} from '@angular/common';
@@ -52,11 +52,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        expect(svg.attr('width')).toEqual('400');
-        expect(svg.attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
         done();
       });
     });
@@ -78,12 +77,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const rects = compiled.querySelectorAll('rect.cell');
-        const rect = d3.select(rects[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('rect.cell');
 
-        expect(rect.attr('width')).toEqual('84');
-        expect(rect.attr('height')).toEqual('254');
+        expect(svg.getAttribute('width')).toBe('84');
+        expect(svg.getAttribute('height')).toBe('254');
         done();
       });
     });
@@ -110,11 +107,9 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const rects = compiled.querySelectorAll('rect.cell');
-        const rect = d3.select(rects[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('rect.cell');
 
-        expect(rect.attr('fill')).toMatch('url(.*)');
+        expect(svg.getAttribute('fill')).toMatch('url(.*)');
         done();
       });
     });
@@ -139,12 +134,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const rects = compiled.querySelectorAll('rect.cell');
-        const rect = d3.select(rects[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('rect.cell');
 
-        expect(rect.attr('width')).toEqual('90');
-        expect(rect.attr('height')).toEqual('260');
+        expect(svg.getAttribute('width')).toBe('90');
+        expect(svg.getAttribute('height')).toBe('260');
         done();
       });
     });
@@ -167,12 +160,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const rects = compiled.querySelectorAll('rect.cell');
-        const rect = d3.select(rects[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('rect.cell');
 
-        expect(rect.attr('width')).toEqual('75');    // ~(360 - 3 * innerPadding) / 4
-        expect(rect.attr('height')).toEqual('246');  // ~(780 - 2 * innnerPadding) / 3
+        expect(svg.getAttribute('width')).toBe('75'); // ~(360 - 3 * innerPadding) / 4
+        expect(svg.getAttribute('height')).toBe('246'); // ~(780 - 2 * innnerPadding) / 3
         done();
       });
     });
@@ -195,12 +186,10 @@ class TestComponent {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const rects = compiled.querySelectorAll('rect.cell');
-        const rect = d3.select(rects[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('rect.cell');
 
-        expect(rect.attr('width')).toEqual('52');    // ~(360 - 3 * innerPadding) / 4
-        expect(rect.attr('height')).toEqual('233');  // ~(780 - 2 * innnerPadding) / 3
+        expect(svg.getAttribute('width')).toBe('52'); // ~(360 - 3 * innerPadding) / 4
+        expect(svg.getAttribute('height')).toBe('233'); // ~(780 - 2 * innnerPadding) / 3
         done();
       });
     });

--- a/src/pie-chart/pie-chart.component.spec.ts
+++ b/src/pie-chart/pie-chart.component.spec.ts
@@ -51,11 +51,10 @@ describe('<ngx-charts-pie>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const svg = d3.select(compiled.querySelectorAll('svg')[0]);
+        const svg = fixture.debugElement.nativeElement.querySelector('svg');
 
-        expect(svg.attr('width')).toEqual('400');
-        expect(svg.attr('height')).toEqual('800');
+        expect(svg.getAttribute('width')).toBe('400');
+        expect(svg.getAttribute('height')).toBe('800');
         done();
       });
     });
@@ -77,8 +76,7 @@ describe('<ngx-charts-pie>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const arcs = compiled.querySelectorAll('path.arc');
+        const arcElement = fixture.debugElement.nativeElement.querySelector('path.arc');
 
         const arc = d3.arc()
           .innerRadius(0)
@@ -86,7 +84,7 @@ describe('<ngx-charts-pie>', () => {
           .startAngle(0)
           .endAngle(1.0996941056424656);
 
-        expect(d3.select(arcs[0]).attr('d')).toEqual(arc());
+        expect(arcElement.getAttribute('d')).toEqual(arc());
         done();
       });
     });
@@ -110,8 +108,7 @@ describe('<ngx-charts-pie>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const arcs = compiled.querySelectorAll('path.arc');
+        const arcElement = fixture.debugElement.nativeElement.querySelector('path.arc');
         const outerRadius = 440 / 3;
 
         const arc = d3.arc()
@@ -120,7 +117,7 @@ describe('<ngx-charts-pie>', () => {
           .startAngle(0)
           .endAngle(1.0996941056424656);
 
-        expect(d3.select(arcs[0]).attr('d')).toEqual(arc());
+        expect(arcElement.getAttribute('d')).toEqual(arc());
         done();
       });
     });
@@ -143,8 +140,7 @@ describe('<ngx-charts-pie>', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const compiled = fixture.debugElement.nativeElement;
-        const arcs = compiled.querySelectorAll('path.arc');
+        const arcElement = fixture.debugElement.nativeElement.querySelector('path.arc');
         const outerRadius = 440 / 3;
 
         const arc = d3.arc()
@@ -153,7 +149,7 @@ describe('<ngx-charts-pie>', () => {
           .startAngle(0)
           .endAngle(1.0996941056424656);
 
-        expect(d3.select(arcs[0]).attr('d')).toEqual(arc());
+        expect(arcElement.getAttribute('d')).toEqual(arc());
         done();
       });
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] CI related changes

**What is the current behavior?** (You can also link to an open issue here)

Tests currently use the d3 selection API to query for elements and attributes.

**What is the new behavior?**

DOM query selection as well as built-in Angular helpers are used to query for elements and attributes.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
