### PR TITLE
fix(number-cards): Card bands should be only rounded on bottom

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -383,7 +383,6 @@
         cardColor="#232837"
         emptyColor="#1e222e"
         [results]="single"
-        [innerPadding]="5"
         (select)="select($event)">
       </ngx-charts-number-card>
       <ngx-charts-gauge

--- a/docs/charts/number-card.md
+++ b/docs/charts/number-card.md
@@ -14,7 +14,7 @@ customColors | object   |                    | custom colors for the chart. Used
 cardColor    | string   |                    | color of the card background, defaults to color based on value and scheme
 bandColor    | string   |                    | color of the card color-bar, defaults to color based on value and scheme
 emptyColor   | string   | 'rgba(0, 0, 0, 0)' | color of empty card slots
-innerPadding | number \| number[] | 2.5      | padding around each card in px
+innerPadding | number \| number[] | 15       | padding around each card in px
 
 # Outputs
 

--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -11,6 +11,7 @@ import {
  } from '@angular/core';
 import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { select } from 'd3-selection';
+import { roundedRect } from '../common/shape.helper';
 
 import { id } from '../utils/id';
 
@@ -133,16 +134,16 @@ export class BarComponent implements OnChanges {
     if (this.roundEdges) {
       if (this.orientation === 'vertical') {
         radius = Math.min(this.height, radius);
-        path = this.roundedRect(this.x, this.y + this.height, this.width, 0, radius, true, true, false, false);
+        path = roundedRect(this.x, this.y + this.height, this.width, 0, radius, true, true, false, false);
       } else if (this.orientation === 'horizontal') {
         radius = Math.min(this.width, radius);
-        path = this.roundedRect(this.x, this.y, 0, this.height, radius, false, true, false, true);
+        path = roundedRect(this.x, this.y, 0, this.height, radius, false, true, false, true);
       }
     } else {
       if (this.orientation === 'vertical') {
-        path = this.roundedRect(this.x, this.y + this.height, this.width, 0, radius, false, false, false, false);
+        path = roundedRect(this.x, this.y + this.height, this.width, 0, radius, false, false, false, false);
       } else if (this.orientation === 'horizontal') {
-        path = this.roundedRect(this.x, this.y, 0, this.height, radius, false, false, false, false);
+        path = roundedRect(this.x, this.y, 0, this.height, radius, false, false, false, false);
       }
     }
 
@@ -156,13 +157,13 @@ export class BarComponent implements OnChanges {
     if (this.roundEdges) {
       if (this.orientation === 'vertical') {
         radius = Math.min(this.height, radius);
-        path = this.roundedRect(this.x, this.y, this.width, this.height, radius, true, true, false, false);
+        path = roundedRect(this.x, this.y, this.width, this.height, radius, true, true, false, false);
       } else if (this.orientation === 'horizontal') {
         radius = Math.min(this.width, radius);
-        path = this.roundedRect(this.x, this.y, this.width, this.height, radius, false, true, false, true);
+        path = roundedRect(this.x, this.y, this.width, this.height, radius, false, true, false, true);
       }
     } else {
-      path = this.roundedRect(this.x, this.y, this.width, this.height, radius, false, false, false, false);
+      path = roundedRect(this.x, this.y, this.width, this.height, radius, false, false, false, false);
     }
 
     return path;
@@ -184,51 +185,6 @@ export class BarComponent implements OnChanges {
     } else {
       return 0.5;
     }
-  }
-
-  roundedRect(x, y, w, h, r, tl, tr, bl, br) {
-    let retval;
-
-    retval = 'M' + (x + r) + ',' + y;
-    retval += 'h' + (w - 2 * r);
-
-    if (tr) {
-      retval += 'a' + r + ',' + r + ' 0 0 1 ' + r + ',' + r;
-    } else {
-      retval += 'h' + r;
-      retval += 'v' + r;
-    }
-
-    retval += 'v' + (h - 2 * r);
-
-    if (br) {
-      retval += 'a' + r + ',' + r + ' 0 0 1 ' + -r + ',' + r;
-    } else {
-      retval += 'v' + r;
-      retval += 'h' + -r;
-    }
-
-    retval += 'h' + (2 * r - w);
-
-    if (bl) {
-      retval += 'a' + r + ',' + r + ' 0 0 1 ' + -r + ',' + -r;
-    } else {
-      retval += 'h' + -r;
-      retval += 'v' + -r;
-    }
-
-    retval += 'v' + (2 * r - h);
-
-    if (tl) {
-      retval += 'a' + r + ',' + r + ' 0 0 1 ' + r + ',' + -r;
-    } else {
-      retval += 'v' + -r;
-      retval += 'h' + r;
-    }
-
-    retval += 'z';
-
-    return retval;
   }
 
   @HostListener('mouseenter')

--- a/src/common/shape.helper.ts
+++ b/src/common/shape.helper.ts
@@ -1,0 +1,47 @@
+/**
+ * Generates a rounded rectanglar path
+ * 
+ * @export
+ * @param {*} x, y, w, h, r, tl, tr, bl, br
+ * @returns {string}
+ */
+export function roundedRect(x, y, w, h, r, tl, tr, bl, br) {
+  let retval = '';
+
+  retval = `M${[x + r, y]}`;
+  retval += `h${w - 2 * r}`;
+
+  if (tr) {
+    retval += `a${[r, r]} 0 0 1 ${[r, r]}`;
+  } else {
+    retval += `h${r}v${r}`;
+  }
+
+  retval += `v${h - 2 * r}`;
+
+  if (br) {
+    retval += `a${[r, r]} 0 0 1 ${[-r, r]}`;
+  } else {
+    retval += `v${r}h${-r}`;
+  }
+
+  retval += `h${2 * r - w}`;
+
+  if (bl) {
+    retval += `a${[r, r]} 0 0 1 ${[-r, -r]}`;
+  } else {
+    retval += `h${-r}v${-r}`;
+  }
+
+  retval += `v${2 * r - h}`;
+
+  if (tl) {
+    retval += `a${[r, r]} 0 0 1 ${[r, -r]}`;
+  } else {
+    retval += `v${-r}h${r}`;
+  }
+
+  retval += `z`;
+
+  return retval;
+}

--- a/src/number-card/card-series.component.ts
+++ b/src/number-card/card-series.component.ts
@@ -55,7 +55,7 @@ export class CardSeriesComponent implements OnChanges {
   @Input() slots: any[];
   @Input() dims;
   @Input() colors;
-  @Input() innerPadding = 2.5;
+  @Input() innerPadding = 15;
 
   @Input() cardColor;
   @Input() bandColor;

--- a/src/number-card/card.component.ts
+++ b/src/number-card/card.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectorRef, NgZone, OnDestroy, ViewEncapsulation
 } from '@angular/core';
 import { trimLabel } from '../common/trim-label.helper';
+import { roundedRect } from '../common/shape.helper';
 import { invertColor } from '../utils/color-utils';
 import { count, decimalChecker } from '../common/count';
 
@@ -22,15 +23,13 @@ import { count, decimalChecker } from '../common/count';
         rx="3"
         ry="3"
       />
-      <svg:rect
+      <svg:path
         *ngIf="bandColor && bandColor !== color"
         class="card-band"
-        [style.fill]="bandColor"
+        [attr.fill]="bandColor"
         [attr.transform]="transformBand"
-        [attr.width]="cardWidth"
-        [attr.height]="bandHeight"
-        rx="3"
-        ry="3"
+        stroke="none"
+        [attr.d]="bandPath"
       />
       <title>{{label}}</title>
       <svg:foreignObject
@@ -100,6 +99,8 @@ export class CardComponent implements OnChanges, OnDestroy {
   textPadding = [10, 20, 10, 20];
   labelFontSize = 12;
 
+  bandPath: string;
+
   constructor(element: ElementRef, private cd: ChangeDetectorRef, private zone: NgZone) {
     this.element = element.nativeElement;
   }
@@ -134,6 +135,8 @@ export class CardComponent implements OnChanges, OnDestroy {
 
       const textHeight = this.textFontSize + 2 * this.labelFontSize;
       this.textPadding[0] = this.textPadding[2] = (this.cardHeight - textHeight - this.bandHeight) / 2 ;
+
+      this.bandPath = roundedRect(0, 0, this.cardWidth, this.bandHeight, 3, false, false, true, true);
 
       setTimeout(() => {
         this.scaleText();
@@ -213,5 +216,4 @@ export class CardComponent implements OnChanges, OnDestroy {
       value: this.data.value
     });
   }
-
 }

--- a/src/number-card/number-card.component.ts
+++ b/src/number-card/number-card.component.ts
@@ -40,7 +40,7 @@ export class NumberCardComponent extends BaseChartComponent {
   @Input() cardColor: string;
   @Input() bandColor: string;
   @Input() emptyColor: string;
-  @Input() innerPadding = 2.5;
+  @Input() innerPadding = 15;
 
   dims: ViewDimensions;
   data: any[];


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Bands in number cards are rounded on all four corners.
Default card spacing is too tight.

**What is the new behavior?**
Bands in number cards are rounded only on bottom corners.
Increased default card spacing.


**Does this PR introduce a breaking change?** (check one with "x")
Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Visual only.