### PR TITLE
feature(number-cards): Ability to set card text color, Fixes #282

### DIFF
--- a/docs/charts/number-card.md
+++ b/docs/charts/number-card.md
@@ -13,6 +13,7 @@ scheme       | object   |                    | the color scheme of the chart
 customColors | object   |                    | custom colors for the chart. Used to override a color for a specific value
 cardColor    | string   |                    | color of the card background, defaults to color based on value and scheme
 bandColor    | string   |                    | color of the card color-bar, defaults to color based on value and scheme
+textColor    | string   |                    | color of the card text, defaults to the inverse of the card color
 emptyColor   | string   | 'rgba(0, 0, 0, 0)' | color of empty card slots
 innerPadding | number \| number[] | 2.5      | padding around each card in px
 

--- a/src/number-card/card-series.component.ts
+++ b/src/number-card/card-series.component.ts
@@ -9,6 +9,7 @@ import {
   NgZone
 } from '@angular/core';
 import { gridSize, gridLayout } from '../common/grid-layout.helper';
+import { invertColor } from '../utils/color-utils';
 
 export interface CardModel {
   x;
@@ -42,6 +43,7 @@ export interface CardModel {
       [height]="c.height"
       [color]="c.color"
       [bandColor]="c.bandColor"
+      [textColor]="c.textColor"
       [data]="c.data"
       [medianSize]="medianSize"
       (select)="onClick($event)"
@@ -60,6 +62,7 @@ export class CardSeriesComponent implements OnChanges {
   @Input() cardColor;
   @Input() bandColor;
   @Input() emptyColor = 'rgba(0, 0, 0, 0)';
+  @Input() textColor;
 
   @Output() select = new EventEmitter();
 
@@ -107,14 +110,16 @@ export class CardSeriesComponent implements OnChanges {
         d.data.name = label;
 
         const value = d.data.value;
-        const labelColor = label ? this.colors.getColor(label) : this.emptyColor;
+        const valueColor = label ? this.colors.getColor(label) : this.emptyColor;
+        const color = this.cardColor || valueColor;
         return {
           x: d.x,
           y: d.y,
           width: d.width - xPadding,
           height: d.height - yPadding,
-          color: this.cardColor || labelColor,
-          bandColor: this.bandColor || labelColor,
+          color,
+          bandColor: this.bandColor || valueColor,
+          textColor: this.textColor || invertColor(color),
           label,
           data: d.data,
           tooltipText: `${label}: ${value}`

--- a/src/number-card/card.component.ts
+++ b/src/number-card/card.component.ts
@@ -4,7 +4,6 @@ import {
   ChangeDetectorRef, NgZone, OnDestroy, ViewEncapsulation
 } from '@angular/core';
 import { trimLabel } from '../common/trim-label.helper';
-import { invertColor } from '../utils/color-utils';
 import { count, decimalChecker } from '../common/count';
 
 @Component({
@@ -42,7 +41,7 @@ import { count, decimalChecker } from '../common/count';
         [attr.height]="labelFontSize + textPadding[2]"
         alignment-baseline="hanging">
         <xhtml:p
-          [style.color]="getTextColor(color)"
+          [style.color]="textColor"
           [style.fontSize.px]="labelFontSize">
           {{trimmedLabel}}
         </xhtml:p>
@@ -51,7 +50,7 @@ import { count, decimalChecker } from '../common/count';
         class="value-text"
         [attr.x]="textPadding[3]"
         [attr.y]="textPadding[0]"
-        [style.fill]="getTextColor(color)"
+        [style.fill]="textColor"
         text-anchor="start"
         alignment-baseline="hanging"
         [style.font-size.pt]="textFontSize">
@@ -65,6 +64,7 @@ export class CardComponent implements OnChanges, OnDestroy {
 
   @Input() color;
   @Input() bandColor;
+  @Input() textColor;
 
   @Input() x;
   @Input() y;
@@ -142,10 +142,6 @@ export class CardComponent implements OnChanges, OnDestroy {
         setTimeout(() => this.startCount(), 20);
       }, 0);
     });
-  }
-
-  getTextColor(color): string {
-    return invertColor(color);
   }
 
   startCount(): void {

--- a/src/number-card/number-card.component.ts
+++ b/src/number-card/number-card.component.ts
@@ -20,6 +20,7 @@ import { gridLayout, gridSize } from '../common/grid-layout.helper';
           [colors]="colors"
           [cardColor]="cardColor"
           [bandColor]="bandColor"
+          [textColor]="textColor"
           [emptyColor]="emptyColor"
           [data]="data"
           [dims]="dims"
@@ -40,6 +41,7 @@ export class NumberCardComponent extends BaseChartComponent {
   @Input() cardColor: string;
   @Input() bandColor: string;
   @Input() emptyColor: string;
+  @Input() textColor: string;
   @Input() innerPadding = 2.5;
 
   dims: ViewDimensions;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Feature


**What is the current behavior?** (You can also link to an open issue here)
Card text is always colored as the inverse of the card color.


**What is the new behavior?**
User can specify the card color.


**Does this PR introduce a breaking change?** (check one with "x")
No