### PR TITLE
fix(bubble): format dates in tooltips

### DIFF
--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -126,16 +126,19 @@ export class BubbleSeriesComponent implements OnChanges {
 
   getTooltipText(circle): string {
     const hasRadius = typeof circle.r !== 'undefined';
-    const radiusValue = hasRadius ? circle.r.toLocaleString() : '';
+    const radiusValue = hasRadius ? formatLabel(circle.r) : '';
     const xAxisLabel = this.xAxisLabel && this.xAxisLabel !== '' ? `${this.xAxisLabel}:` : '';
     const yAxisLabel = this.yAxisLabel && this.yAxisLabel !== '' ? `${this.yAxisLabel}:` : '';
+    const x = formatLabel(circle.x);
+    const y = formatLabel(circle.y);
+    
     return `
       <span class="tooltip-label">
         ${circle.seriesName} • ${circle.tooltipLabel}
       </span>
       <span class="tooltip-label">
-        <label>${xAxisLabel}</label> ${circle.x.toLocaleString()}<br />
-        <label>${yAxisLabel}</label> ${circle.y.toLocaleString()}
+        <label>${xAxisLabel}</label> ${x}<br />
+        <label>${yAxisLabel}</label> ${y}
       </span>
       <span class="tooltip-val">
         ${radiusValue}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Dates in tools tips are not properly formatted.


**What is the new behavior?**
Dates in tools tips are now properly formatted.


**Does this PR introduce a breaking change?** (check one with "x")
No
