### PR TITLE
fix(line-chart): only round linear scales, Fixes #254

### DIFF
--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -318,6 +318,10 @@ export class LineChartComponent extends BaseChartComponent {
       scale = scaleLinear()
         .range([0, width])
         .domain(domain);
+ 
+      if (this.roundDomains) {
+        scale = scale.nice();
+      }
     } else if (this.scaleType === 'ordinal') {
       scale = scalePoint()
         .range([0, width])
@@ -325,7 +329,7 @@ export class LineChartComponent extends BaseChartComponent {
         .domain(domain);
     }
 
-    return this.roundDomains ? scale.nice() : scale;
+    return scale;
   }
 
   getYScale(domain, height): any {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Throws an error when `roundDomains` is set to true on ordinal scales.


**What is the new behavior?**
`roundDomains` only applies to linear scales.


**Does this PR introduce a breaking change?** (check one with "x")
No
