### PR TITLE
If the total is 0, return 0 as the percent

### DIFF
--- a/src/common/grid-layout.helper.ts
+++ b/src/common/grid-layout.helper.ts
@@ -53,7 +53,7 @@ export function gridLayout(dims, data, minWidth) {
     res[i].y = yScale(Math.floor(i / columns));
     res[i].width = cardWidth;
     res[i].height = cardHeight;
-    res[i].data.percent = res[i].data.value / total;
+    res[i].data.percent = (total > 0) ? res[i].data.value / total : 0;
     res[i].data.total = total;
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix


**What is the current behavior?** 

Pie grids with a total of 0 show `NaN%`: https://github.com/swimlane/ngx-charts/issues/286


**What is the new behavior?**

If the pie grid total is 0, show `0%`.

**Does this PR introduce a breaking change?**
- [x] No

