### PR TITLE
refactor(pie-chart): use CSS animations for labels

### DIFF
--- a/src/pie-chart/pie-chart.component.scss
+++ b/src/pie-chart/pie-chart.component.scss
@@ -1,3 +1,28 @@
 .pie-label {
   font-size: 11px;
+  animation: 750ms ease-in fadeIn;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+.pie-label-line {
+  animation: 3s linear drawOut;
+  stroke-dasharray: 100%;
+  transition: d 750ms;
+
+  @keyframes drawOut {
+    from {
+      stroke-dashoffset: 100%;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)

Pie chart labels use the d3 selection and transition APIs.

**What is the new behavior?**

CSS animations are now used.  IE browsers do not support CSS transforms with SVG; as a result the existing visual behavior is maintained for IE.  Safari has a bug which prevents a CSS transform of a text element from being updated properly.  A group is introduced around the text element to allow the transforms to function.  Also, currently only Chrome supports transition animations of the `d` attribute; allowing Chrome the best visual experience.  However, other browsers fallback to existing visual behavior.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
