### PR TITLE
Support more options for pie chart label processing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
       "**/node_modules": true,
       "dist": true,
       "release": true
-    }
+    },
+    "angulardoc.repoId": "423d256a-6da4-4f13-944d-ee69532bdc68",
+    "angulardoc.lastSync": 0
 }

--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -189,6 +189,7 @@
         [legend]="showLegend"
         [explodeSlices]="explodeSlices"
         [labels]="showLabels"
+        [pieLabelOption]="pieLabelOption$ | async"
         [doughnut]="doughnut"
         [arcWidth]="arcWidth"
         (legendLabelClick)="onLegendLabelClick($event)"
@@ -716,6 +717,15 @@
 
       <div *ngIf="chart.options.includes('maxRadius')">
         <label>Maximum Radius:</label><input type="number" [(ngModel)]="maxRadius">
+      </div>
+
+      <div *ngIf="chart.options.includes('pieLabelOption')">
+        <label>
+          <input type="checkbox" [(ngModel)]="pieLabelOption.trimLabel" (change)="pieLabelOptionChanged()">
+          Trim Label
+        </label> <br />
+        <label>Pie Label Max Length:</label><br />
+        <input type="number" [(ngModel)]="pieLabelOption.trimLabelMaxLength" (change)="pieLabelOptionChanged()"><br />
       </div>
 
     </div>

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import * as shape from 'd3-shape';
+import { Observable } from 'rxjs/Rx';
 
 import { colorSets } from '../src/utils/color-sets';
 import { single, multi, countries, bubble, generateData, generateGraph } from './data';
 import chartGroups from './chartTypes';
+import { PieLabelOption } from '../src/common';
 
 @Component({
   selector: 'app',
@@ -81,6 +83,10 @@ export class AppComponent implements OnInit {
   doughnut = false;
   arcWidth = 0.25;
 
+  // pie chart label options
+  pieLabelOption = new PieLabelOption();
+  pieLabelOption$: Observable<PieLabelOption>;
+
   // line, area
   autoScale = true;
   timeline = false;
@@ -138,6 +144,8 @@ export class AppComponent implements OnInit {
     if (!this.fitContainer) {
       this.applyDimensions();
     }
+
+    this.pieLabelOption$ = Observable.of(this.pieLabelOption);
   }
 
   updateData() {
@@ -328,6 +336,12 @@ export class AppComponent implements OnInit {
 
   onLegendLabelClick(entry) {
     console.log('Legend clicked', entry);
+  }
+
+  pieLabelOptionChanged() {
+    console.log(`Pie label option changed: ${JSON.stringify(this.pieLabelOption)}`);
+    const newPieLabelOption = Object.assign({}, this.pieLabelOption);
+    this.pieLabelOption$ = Observable.of(newPieLabelOption);
   }
 
 }

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -93,7 +93,7 @@ const chartGroups = [
         inputFormat: 'singleSeries',
         options: [
           'colorScheme', 'gradient', 'showLegend', 'doughnut', 'arcWidth',
-          'explodeSlices', 'showLabels', 'tooltipDisabled'
+          'explodeSlices', 'showLabels', 'tooltipDisabled', 'pieLabelOption'
         ]
       },
       {

--- a/docs/charts/pie-chart.md
+++ b/docs/charts/pie-chart.md
@@ -5,20 +5,27 @@
 
 # Inputs
 
-Property      | Type     | Default Value | Description
-:------------ | :------- | :------------ | :--------------------------------------------------------------------------------------------------------------
-view          | number[] |               | the dimensions of the chart [width, height]. If left undefined, the chart will fit to the parent container size
-results       | object[] |               | the chart data
-scheme        | object   |               | the color scheme of the chart
-customColors  | object   |               | custom colors for the chart. Used to override a color for a specific value
-labels        | boolean  | false         | show or hide the labels
-legend        | boolean  | false         | show or hide the legend
-explodeSlices | boolean  | false         | make the radius of each slice proportional to it's value
-doughnut      | boolean  | false         | should doughnut instead of pie slices
-arcWidth      | number   | 0.25          | arc width, expressed as a fraction of outer radius
-gradient      | boolean  | false         | fill elements with a gradient instead of a solid color
-activeEntries | object[] | []            | elements to highlight
-tooltipDisabled     | boolean  | false         | show or hide the tooltip
+Property       | Type          | Default Value | Description
+:------------- | :------------ | :------------ | :--------------------------------------------------------------------------------------------------------------
+view           | number[]      |               | the dimensions of the chart [width, height]. If left undefined, the chart will fit to the parent container size
+results        | object[]      |               | the chart data
+scheme         | object        |               | the color scheme of the chart
+customColors   | object        |               | custom colors for the chart. Used to override a color for a specific value
+labels         | boolean       | false         | show or hide the labels
+legend         | boolean       | false         | show or hide the legend
+explodeSlices  | boolean       | false         | make the radius of each slice proportional to it's value
+doughnut       | boolean       | false         | should doughnut instead of pie slices
+arcWidth       | number        | 0.25          | arc width, expressed as a fraction of outer radius
+gradient       | boolean       | false         | fill elements with a gradient instead of a solid color
+activeEntries  | object[]      | []            | elements to highlight
+tooltipDisabled| boolean       | false         | show or hide the tooltip
+pieLabelOption | [PieLabelOption](#pie-label-option)|        | optional input for fine control on pie label processing 
+
+## PieLabelOption <a id="pie-label-option"></a>
+Property              | Type          | Default Value | Description
+:-------------------- | :------------ | :------------ | :--------------------------------------------------------------------------------------------------------------
+trimLabel             | boolean       | true          | Whether to trim pie chart label
+trimLabelMaxLength    | number        | 10            | Max. length of trim pie chart label. Only apply when trimLabel is true
 
 # Outputs
 

--- a/src/common/chart.model.ts
+++ b/src/common/chart.model.ts
@@ -1,0 +1,4 @@
+export class PieLabelOption {
+  trimLabel: boolean = true;
+  trimLabelMaxLength: number = 10;
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -19,3 +19,4 @@ export * from './tick-format.helper';
 export * from './trim-label.helper';
 export * from './view-dimensions.helper';
 export * from './label.helper';
+export * from './chart.model';

--- a/src/pie-chart/pie-chart.component.ts
+++ b/src/pie-chart/pie-chart.component.ts
@@ -9,6 +9,7 @@ import {
 import { calculateViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
+import { PieLabelOption } from '../common';
 
 @Component({
   selector: 'ngx-charts-pie-chart',
@@ -25,6 +26,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
         <svg:g ngx-charts-pie-series
           [colors]="colors"
           [showLabels]="labels"
+          [pieLabelOption]="pieLabelOption"
           [series]="data"
           [activeEntries]="activeEntries"
           [innerRadius]="innerRadius"
@@ -56,6 +58,7 @@ export class PieChartComponent extends BaseChartComponent {
   @Input() gradient: boolean;
   @Input() activeEntries: any[] = [];
   @Input() tooltipDisabled: boolean = false;
+  @Input() pieLabelOption = new PieLabelOption();
 
   @Output() select = new EventEmitter();
   @Output() activate: EventEmitter<any> = new EventEmitter();

--- a/src/pie-chart/pie-label.component.ts
+++ b/src/pie-chart/pie-label.component.ts
@@ -14,6 +14,7 @@ import { select } from 'd3-selection';
 import { arc } from 'd3-shape';
 
 import { trimLabel } from '../common/trim-label.helper';
+import { PieLabelOption } from '../common';
 
 @Component({
   selector: 'g[ngx-charts-pie-label]',
@@ -27,7 +28,7 @@ import { trimLabel } from '../common/trim-label.helper';
       [style.textAnchor]="textAnchor()"
       [style.shapeRendering]="'crispEdges'"
       [style.textTransform]="'uppercase'">
-      {{trimLabel(label, 10)}}
+      {{formatPieLabel(label)}}
     </svg:text>
     <svg:path
       [@animationState]="'active'"
@@ -60,6 +61,7 @@ export class PieLabelComponent implements OnChanges {
   @Input() max;
   @Input() value;
   @Input() explodeSlices;
+  @Input() pieLabelOption: PieLabelOption;
 
   element: HTMLElement;
   trimLabel: (label: string, max?: number) => string;
@@ -128,6 +130,26 @@ export class PieLabelComponent implements OnChanges {
       .style('stroke-dashoffset', '0')
       .transition()
       .style('stroke-dasharray', 'none');
+  }
+
+  /**
+   * Format pie label base on provided options
+   * 
+   * @param {string} label 
+   * @returns {string} 
+   * 
+   * @memberOf PieLabelComponent
+   */
+  formatPieLabel(label: string): string {
+
+    let formattedLabel = label;
+
+    if (this.pieLabelOption.trimLabel) {
+      formattedLabel = this.trimLabel(label, this.pieLabelOption.trimLabelMaxLength);
+    }
+
+    return formattedLabel;
+
   }
 
 }

--- a/src/pie-chart/pie-series.component.ts
+++ b/src/pie-chart/pie-series.component.ts
@@ -11,6 +11,7 @@ import { max } from 'd3-array';
 import { arc, pie } from 'd3-shape';
 
 import { formatLabel } from '../common/label.helper';
+import { PieLabelOption } from '../common';
 
 @Component({
   selector: 'g[ngx-charts-pie-series]',
@@ -22,6 +23,7 @@ import { formatLabel } from '../common/label.helper';
         [radius]="outerRadius"
         [color]="color(arc)"
         [label]="label(arc)"
+        [pieLabelOption]="pieLabelOption"
         [max]="max"
         [value]="arc.value"
         [explodeSlices]="explodeSlices">
@@ -64,6 +66,7 @@ export class PieSeriesComponent implements OnChanges {
   @Input() gradient: boolean;
   @Input() activeEntries: any[];
   @Input() tooltipDisabled: boolean = false;
+  @Input() pieLabelOption: PieLabelOption;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();


### PR DESCRIPTION
Support more options for pie chart label processing

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Other... Please describe:
Add an optional input to pie chart component to support more fine grained control on the processing of pie chart labels.

**What is the current behavior?** (You can also link to an open issue here)
Currently for the pie chart, the label is hard code to be trimmed and the max. length to 10.

**What is the new behavior?**
For pie chart component, a new optional input "pieLabelOption" was added, which allow the developer to provide more control on how to render the pie chart label. Instead of hardcode, the pie label component now will render the label base on the input configuration. 2 options were provided at the moment:
- trimLabel: boolean (whether to trim label or not)
- trimLabelMaxLength: number (if trim label, max length of label)
The input is optional. If not provided, the default values will be used, which is the same as current behaviour (can be found in the newly added class /src/common/chart.model.ts)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
The demo app and documentation page was also updated.