### PR TITLE
feature(heatmap): More heatmap options and calendar example

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -380,7 +380,6 @@
         [xAxisTickFormatting]="calendarAxisTickFormatting"
         [tooltipText]="calendarTooltipText"
         [innerPadding]="2"
-        [scaleType]="'linear'"
         [tooltipDisabled]="tooltipDisabled"
         (select)="select($event)">
       </ngx-charts-heat-map>

--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -364,6 +364,26 @@
         [tooltipDisabled]="tooltipDisabled"
         (select)="select($event)">
       </ngx-charts-heat-map>
+      <ngx-charts-heat-map
+        *ngIf="chartType === 'calendar'"
+        class="chart-container"
+        [view]="view"
+        [scheme]="colorScheme"
+        [results]="calendarData"
+        [legend]="showLegend"
+        [gradient]="gradient"
+        (legendLabelClick)="onLegendLabelClick($event)"
+        [xAxis]="showXAxis"
+        [yAxis]="showYAxis"
+        [showXAxisLabel]="false"
+        [showYAxisLabel]="false"
+        [xAxisTickFormatting]="calendarAxisTickFormatting"
+        [tooltipText]="calendarTooltipText"
+        [innerPadding]="2"
+        [scaleType]="'linear'"
+        [tooltipDisabled]="tooltipDisabled"
+        (select)="select($event)">
+      </ngx-charts-heat-map>
       <ngx-charts-tree-map
         *ngIf="chartType === 'tree-map'"
         class="chart-container"

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -5,6 +5,9 @@ import { colorSets } from '../src/utils/color-sets';
 import { single, multi, countries, bubble, generateData, generateGraph } from './data';
 import chartGroups from './chartTypes';
 
+const monthName = new Intl.DateTimeFormat('en-us', { month: 'short' });
+const weekdayName = new Intl.DateTimeFormat('en-us', { weekday: 'short' });
+
 @Component({
   selector: 'app',
   encapsulation: ViewEncapsulation.None,
@@ -25,6 +28,7 @@ export class AppComponent implements OnInit {
   multi: any[];
   dateData: any[];
   dateDataWithRange: any[];
+  calendarData: any[];
   graph: { links: any[], nodes: any[] };
   bubble: any;
   linearScale: boolean = false;
@@ -119,6 +123,7 @@ export class AppComponent implements OnInit {
     this.dateData = generateData(5, false);
     this.dateDataWithRange = generateData(2, true);
     this.setColorScheme('cool');
+    this.calendarData = this.getCalendarData();
   }
 
   get dateDataWithOrWithoutRange() {
@@ -237,6 +242,8 @@ export class AppComponent implements OnInit {
 
     this.dateData = generateData(5, false);
     this.dateDataWithRange = generateData(2, true);
+
+    if (this.chart.inputFormat === 'calendarData') this.calendarData = this.getCalendarData();
   }
 
   applyDimensions() {
@@ -268,6 +275,18 @@ export class AppComponent implements OnInit {
     } else {
       this.yAxisLabel = 'GDP Per Capita';
       this.xAxisLabel = 'Country';
+    }
+
+    if (this.chartType === 'calendar') {
+      this.width = 1100;
+      this.height = 200;
+    } else {
+      this.width = 700;
+      this.height = 300;
+    }
+
+    if (!this.fitContainer) {
+      this.applyDimensions();
     }
 
     for (const group of this.chartGroups) {
@@ -328,6 +347,71 @@ export class AppComponent implements OnInit {
 
   onLegendLabelClick(entry) {
     console.log('Legend clicked', entry);
+  }
+
+  getCalendarData(): any[] {
+    // today
+    const now = new Date();
+    const todaysDay = now.getDate();
+    const thisDay = new Date(now.getFullYear(), now.getMonth(), todaysDay);
+
+    // Monday
+    const thisMonday = new Date(thisDay.getFullYear(), thisDay.getMonth(), todaysDay - thisDay.getDay() + 1);
+    const thisMondayDay = thisMonday.getDate();
+    const thisMondayYear = thisMonday.getFullYear();
+    const thisMondayMonth = thisMonday.getMonth();
+
+    // 52 weeks before monday
+    const calendarData = [];
+    const getDate = d => new Date(thisMondayYear, thisMondayMonth, d);
+    for (let week = -52; week <= 0; week++) {
+      const mondayDay = thisMondayDay + (week * 7);
+      const monday = getDate(mondayDay);
+
+      // one week
+      const series = [];
+      for (let dayOfWeek = 7; dayOfWeek > 0; dayOfWeek--) {
+        const date = getDate(mondayDay - 1 + dayOfWeek);
+
+        // skip future dates
+        if (date > now) {
+          continue;
+        }
+
+        // value
+        const value = (dayOfWeek < 6) ? (date.getMonth() + 1) : 0;
+
+        series.push({
+          date,
+          name: weekdayName.format(date),
+          value
+        });
+      }
+
+      calendarData.push({
+        name: `Week of ${monday.toLocaleDateString()}`,
+        series
+      });
+    }
+
+    return calendarData;
+  }
+
+  calendarAxisTickFormatting(mondayString: string) {
+    const monday = new Date(mondayString.replace('Week of ', ''));
+    const month = monday.getMonth();
+    const day = monday.getDate();
+    const year = monday.getFullYear();
+    const lastSunday = new Date(year, month, day - 1);
+    const nextSunday = new Date(year, month, day + 6);
+    return (lastSunday.getMonth() !== nextSunday.getMonth()) ? monthName.format(nextSunday) : '';
+  }
+
+  calendarTooltipText(c): string {
+    return `
+      <span class="tooltip-label">${c.label} • ${c.cell.date.toLocaleDateString()}</span>
+      <span class="tooltip-val">${c.data.toLocaleString()}</span>
+    `;
   }
 
 }

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -189,6 +189,15 @@ const chartGroups = [
         ]
       },
       {
+        name: 'Heat Map - Calendar',
+        selector: 'calendar',
+        inputFormat: 'calendarData',
+        options: [
+          'colorScheme', 'showXAxis', 'showYAxis', 'gradient', 'showLegend',
+          'innerPadding', 'tooltipDisabled'
+        ]
+      },
+      {
         name: 'Tree Map',
         selector: 'tree-map',
         inputFormat: 'singleSeries',

--- a/docs/charts/heat-map.md
+++ b/docs/charts/heat-map.md
@@ -22,6 +22,7 @@ yAxisTickFormatting | function |               | the y axis tick formatting
 gradient            | boolean  | false         | fill elements with a gradient instead of a solid color
 innerPadding        | number \ | number[]      | 8                                                                                                               | the inner padding in px
 tooltipDisabled     | boolean  | false         | show or hide the tooltip
+tooltipText         | function | (see source)  | the HTML text to display in the tooltip
 
 # Outputs
 

--- a/src/heat-map/heat-map-cell-series.component.ts
+++ b/src/heat-map/heat-map-cell-series.component.ts
@@ -5,8 +5,10 @@ import {
   Output,
   EventEmitter,
   OnChanges,
+  OnInit,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { formatLabel } from '../common/label.helper';
 
 @Component({
   selector: 'g[ngx-charts-heat-map-cell-series]',
@@ -26,12 +28,12 @@ import {
       [tooltipDisabled]="tooltipDisabled"
       [tooltipPlacement]="'top'"
       [tooltipType]="'tooltip'"
-      [tooltipTitle]="getTooltipText(c)"
+      [tooltipTitle]="tooltipText(c)"
     />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HeatCellSeriesComponent implements OnChanges {
+export class HeatCellSeriesComponent implements OnChanges, OnInit {
 
   @Input() data;
   @Input() colors;
@@ -39,10 +41,17 @@ export class HeatCellSeriesComponent implements OnChanges {
   @Input() yScale;
   @Input() gradient: boolean;
   @Input() tooltipDisabled: boolean = false;
+  @Input() tooltipText: Function;
 
   @Output() select = new EventEmitter();
 
   cells: any[];
+
+  ngOnInit() {
+    if (!this.tooltipText) {
+      this.tooltipText = this.getTooltipText;
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
@@ -59,20 +68,16 @@ export class HeatCellSeriesComponent implements OnChanges {
       row.series.map((cell) => {
         const value = cell.value;
 
-        const label = cell.name;
-        let tooltipLabel = label;
-        if (tooltipLabel.constructor.name === 'Date') {
-          tooltipLabel = tooltipLabel.toLocaleDateString();
-        }
-
         cells.push({
+          row,
+          cell,
           x: this.xScale(row.name),
           y: this.yScale(cell.name),
           width: this.xScale.bandwidth(),
           height: this.yScale.bandwidth(),
           fill: this.colors.getColor(value),
           data: value,
-          label,
+          label: formatLabel(cell.name),
           series: row.name
         });
       });

--- a/src/heat-map/heat-map-cell-series.component.ts
+++ b/src/heat-map/heat-map-cell-series.component.ts
@@ -41,7 +41,7 @@ export class HeatCellSeriesComponent implements OnChanges, OnInit {
   @Input() yScale;
   @Input() gradient: boolean;
   @Input() tooltipDisabled: boolean = false;
-  @Input() tooltipText: Function;
+  @Input() tooltipText: any;
 
   @Output() select = new EventEmitter();
 

--- a/src/heat-map/heat-map.component.ts
+++ b/src/heat-map/heat-map.component.ts
@@ -52,6 +52,7 @@ import { ColorHelper } from '../common/color.helper';
           [data]="results"
           [gradient]="gradient"
           [tooltipDisabled]="tooltipDisabled"
+          [tooltipText]="tooltipText"
           (select)="onClick($event)"
         />
       </svg:g>
@@ -75,6 +76,8 @@ export class HeatMapComponent extends BaseChartComponent {
   @Input() xAxisTickFormatting: any;
   @Input() yAxisTickFormatting: any;
   @Input() tooltipDisabled: boolean = false;
+  @Input() scaleType: string = 'linear';
+  @Input() tooltipText: any;
 
   dims: ViewDimensions;
   xDomain: any[];
@@ -107,7 +110,7 @@ export class HeatMapComponent extends BaseChartComponent {
         showXLabel: this.showXAxisLabel,
         showYLabel: this.showYAxisLabel,
         showLegend: this.legend,
-        legendType: 'linear'
+        legendType: this.scaleType
       });
 
       this.formatDates();
@@ -163,6 +166,10 @@ export class HeatMapComponent extends BaseChartComponent {
       }
     }
 
+    if (this.scaleType === 'ordinal') {
+      return domain.sort();
+    }
+    
     const min = Math.min(0, ...domain);
     const max = Math.max(...domain);
 
@@ -211,14 +218,14 @@ export class HeatMapComponent extends BaseChartComponent {
   }
 
   setColors(): void {
-    this.colors = new ColorHelper(this.scheme, 'linear', this.valueDomain);
+    this.colors = new ColorHelper(this.scheme, this.scaleType, this.valueDomain);
   }
 
   getLegendOptions() {
     return {
-      scaleType: 'linear',
+      scaleType: this.scaleType,
       domain: this.valueDomain,
-      colors: this.colors.scale
+      colors: this.scaleType === 'ordinal' ? this.colors : this.colors.scale
     };
   }
 

--- a/src/heat-map/heat-map.component.ts
+++ b/src/heat-map/heat-map.component.ts
@@ -76,7 +76,6 @@ export class HeatMapComponent extends BaseChartComponent {
   @Input() xAxisTickFormatting: any;
   @Input() yAxisTickFormatting: any;
   @Input() tooltipDisabled: boolean = false;
-  @Input() scaleType: string = 'linear';
   @Input() tooltipText: any;
 
   dims: ViewDimensions;
@@ -94,6 +93,7 @@ export class HeatMapComponent extends BaseChartComponent {
   xAxisHeight: number = 0;
   yAxisWidth: number = 0;
   legendOptions: any;
+  scaleType: string = 'linear';
 
   update(): void {
     super.update();
@@ -118,6 +118,14 @@ export class HeatMapComponent extends BaseChartComponent {
       this.xDomain = this.getXDomain();
       this.yDomain = this.getYDomain();
       this.valueDomain = this.getValueDomain();
+
+      this.scaleType = this.getScaleType(this.valueDomain);
+
+      if (this.scaleType === 'linear') {
+        const min = Math.min(0, ...this.valueDomain);
+        const max = Math.max(...this.valueDomain);
+        this.valueDomain = [min, max];
+      }
 
       this.xScale = this.getXScale();
       this.yScale = this.getYScale();
@@ -166,14 +174,7 @@ export class HeatMapComponent extends BaseChartComponent {
       }
     }
 
-    if (this.scaleType === 'ordinal') {
-      return domain.sort();
-    }
-    
-    const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
-
-    return [min, max];
+    return domain;
   }
 
   getXScale(): any {
@@ -215,6 +216,19 @@ export class HeatMapComponent extends BaseChartComponent {
 
   onClick(data): void {
     this.select.emit(data);
+  }
+
+  getScaleType(values): string {
+    let num = true;
+
+    for (const value of values) {
+      if (typeof value !== 'number') {
+        num = false;
+      }
+    }
+
+    if (num) return 'linear';
+    return 'ordinal';
   }
 
   setColors(): void {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Feature
Demo

**What is the new behavior?**
Heat map now supports `tooltipText` and `scaleType` as inputs.
Added heat map - calendar demo:

![image](https://cloud.githubusercontent.com/assets/509946/24280720/305c372a-1096-11e7-8820-3a059fd267f5.png)

**Does this PR introduce a breaking change?** (check one with "x")
No

