### PR TITLE
feature(heat-map): support various inputs for innerPadding

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -652,7 +652,7 @@
       </div>
       <div *ngIf="chart.options.includes('innerPadding')">
         <label>Inner padding value:</label><br />
-        <input type="number" [(ngModel)]="innerPadding" min="0" step="1"><br />
+        <input type="text" [(ngModel)]="innerPadding" min="0" step="1"><br />
       </div>
       <div *ngIf="chart.options.includes('barPadding')">
         <label>Padding between bars:</label><br />

--- a/src/heat-map/heat-map.component.ts
+++ b/src/heat-map/heat-map.component.ts
@@ -169,9 +169,45 @@ export class HeatMapComponent extends BaseChartComponent {
     return [min, max];
   }
 
+  /**
+   * Converts the input to gap paddingInner in fraction
+   * Supports the following inputs:
+   *    Numbers: 8
+   *    Strings: "8", "8px", "8%"
+   *    Arrays: [8,2], "8,2", "[8,2]"
+   *    Mixed: [8,"2%"], ["8px","2%"], "8,2%", "[8,2%]"
+   * 
+   * @param {(string | number | Array<string | number>)} value 
+   * @param {number} [index=0] 
+   * @param {number} N 
+   * @param {number} L 
+   * @returns {number} 
+   * 
+   * @memberOf HeatMapComponent
+   */
+  getDimension(value: string | number | Array<string | number>, index = 0, N: number, L: number): number {
+    if (typeof value === 'string') {
+      value = value
+        .replace('[', '')
+        .replace(']', '')
+        .replace('px', '')
+        .replace('\'', '');
+
+      if (value.includes(',')) {
+        value = value.split(',');
+      }
+    }
+    if (Array.isArray(value) && typeof index === 'number') {
+      return this.getDimension(value[index], null, N, L);
+    }
+    if (typeof value === 'string' && value.includes('%')) {
+      return +value.replace('%', '') / 100;
+    }
+    return N / (L / +value + 1);
+  }
+
   getXScale(): any {
-    const innerPadding = typeof this.innerPadding === 'number' ? this.innerPadding : this.innerPadding[0];
-    const f = this.xDomain.length / (this.dims.width / innerPadding + 1);
+    const f = this.getDimension(this.innerPadding, 0, this.xDomain.length, this.dims.width);
     return scaleBand()
       .rangeRound([0, this.dims.width])
       .domain(this.xDomain)
@@ -179,8 +215,7 @@ export class HeatMapComponent extends BaseChartComponent {
   }
 
   getYScale(): any {
-    const innerPadding = typeof this.innerPadding === 'number' ? this.innerPadding : this.innerPadding[1];
-    const f = this.yDomain.length / (this.dims.height / innerPadding + 1);
+    const f = this.getDimension(this.innerPadding, 1, this.yDomain.length, this.dims.height);
     return scaleBand()
       .rangeRound([this.dims.height, 0])
       .domain(this.yDomain)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature


**What is the current behavior?** (You can also link to an open issue here)
`innerPadding` only supports numbers and arrays of numbers as inputs.


**What is the new behavior?**
`innerPadding` supports the following inputs:

Numbers: `8`
Strings: `"8"`, `"8px"`, `"8%"`
Arrays: `[8,2]`, `"8,2"`, `"[8,2]"`
Mixed: `[8,"2%"]`, `["8px","2%"]`, `"8,2%"`, `"[8,2%]"`

If no unit is given assumes `px`.

**Does this PR introduce a breaking change?**
No


**Other information**:
If this approach looks good I can apply to other charts as well.
