### PR TITLE
Add "extra" field to cloneData() items 

### DIFF
--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -169,6 +169,10 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
           copy['series'].push(seriesItemCopy);
         }
       }
+      
+      if(item['extra'] !== undefined){
+        copy['extra'] = JSON.parse(JSON.stringify(item['extra'])); 
+      }
 
       results.push(copy);
     }

--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -170,7 +170,7 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
         }
       }
       
-      if(item['extra'] !== undefined){
+      if(item['extra'] !== undefined) {
         copy['extra'] = JSON.parse(JSON.stringify(item['extra'])); 
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
At this time, only value, name and series fields of data entries are copied, so if you need more data to retrieve ie on select event can't get it.
In the series type of chart, is a side effect of the "Object.assign({}, seriesItem);" used to copy the series.


**What is the new behavior?**
Now you can pass an "extra" data object to retrieve on chart events


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

**Other information**:
