### PR TITLE
fix: don't bundle @angular/animations

### DIFF
--- a/config/webpack.package.js
+++ b/config/webpack.package.js
@@ -40,6 +40,7 @@ module.exports = function(env) {
       umdNamedDefine: true
     },
     externals: {
+      '@angular/animations': '@angular/animations',
       '@angular/platform-browser-dynamic': '@angular/platform-browser-dynamic',
       '@angular/platform-browser': '@angular/platform-browser',
       '@angular/core': '@angular/core',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

@angular/animations was being bundled in the release output.

**What is the new behavior?**

No longer bundled.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

A patch release may be warranted as this could cause build issues for users of the package.
