### PR TITLE
feature: added option in line-chart for disabling series on hover

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -240,6 +240,7 @@
         [rangeFillOpacity]="rangeFillOpacity"
         [roundDomains]="roundDomains"
         [tooltipDisabled]="tooltipDisabled"
+        [showSeriesOnHover]="showSeriesOnHover"
         (select)="select($event)">
       </ngx-charts-line-chart>
       <ngx-charts-bubble-chart

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -56,6 +56,7 @@ export class AppComponent implements OnInit {
   roundDomains = false;
   maxRadius = 10;
   minRadius = 3;
+  showSeriesOnHover = true;
 
   // line interpolation
   curveType: string = 'Linear';

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -145,6 +145,7 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() roundDomains: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() showSeriesOnHover: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -438,8 +439,7 @@ export class LineChartComponent extends BaseChartComponent {
     if (idx > -1) {
       return;
     }
-
-    this.activeEntries = [ item, ...this.activeEntries ];
+    this.activeEntries = this.showSeriesOnHover ? [ item, ...this.activeEntries ] : this.activeEntries;
     this.activate.emit({ value: item, entries: this.activeEntries });
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Takes care of #319 

**What is the new behavior?**
- For line-chart, a new template option `showSeriesOnHover` has been added which can be set as true/false. 
- If set as `false`, all the data points on line will *not* be highlighted on hovering. This will stop the action which happens in case of current behavior where on hover, it adds all the line items to `activeEntries` and highlights all the g tags for that line which can become a performance hit in case of bigger data set.
- Default is `true`.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

