### PR TITLE
Invert y-axis on horizontal bar charts

### DIFF
--- a/src/bar-chart/bar-horizontal-2d.component.ts
+++ b/src/bar-chart/bar-horizontal-2d.component.ts
@@ -169,7 +169,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
     const spacing = this.groupDomain.length / (this.dims.height / this.groupPadding + 1);
 
     return scaleBand()
-      .rangeRound([this.dims.height, 0])
+      .rangeRound([0, this.dims.height])
       .paddingInner(spacing)
       .paddingOuter(spacing / 2)
       .domain(this.groupDomain);

--- a/src/bar-chart/bar-horizontal-normalized.component.ts
+++ b/src/bar-chart/bar-horizontal-normalized.component.ts
@@ -190,7 +190,7 @@ export class BarHorizontalNormalizedComponent extends BaseChartComponent {
     const spacing = this.groupDomain.length / (this.dims.height / this.barPadding + 1);
 
     return scaleBand()
-      .rangeRound([this.dims.height, 0])
+      .rangeRound([0, this.dims.height])
       .paddingInner(spacing)
       .domain(this.groupDomain);
   }

--- a/src/bar-chart/bar-horizontal-stacked.component.ts
+++ b/src/bar-chart/bar-horizontal-stacked.component.ts
@@ -204,7 +204,7 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
     const spacing = this.groupDomain.length / (this.dims.height / this.barPadding + 1);
 
     return scaleBand()
-      .rangeRound([this.dims.height, 0])
+      .rangeRound([0, this.dims.height])
       .paddingInner(spacing)
       .domain(this.groupDomain);
   }

--- a/src/bar-chart/bar-horizontal.component.ts
+++ b/src/bar-chart/bar-horizontal.component.ts
@@ -138,7 +138,7 @@ export class BarHorizontalComponent extends BaseChartComponent {
     const spacing = this.yDomain.length / (this.dims.height / this.barPadding + 1);
 
     return scaleBand()
-      .rangeRound([this.dims.height, 0])
+      .rangeRound([0, this.dims.height])
       .paddingInner(spacing)
       .domain(this.yDomain);
   }


### PR DESCRIPTION
 to match legend and input.

**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Horizontal bar charts have bars positioned in an order inverse of the domain input and the legend.

![image](https://cloud.githubusercontent.com/assets/509946/25018412/81c0bc22-2044-11e7-858e-945b9cdaeec7.png)



**What is the new behavior?**
Horizontal bar charts should have bars positioned in an order matching the domain input and the legend.

![image](https://cloud.githubusercontent.com/assets/509946/25018421/86520a20-2044-11e7-9f34-4e71654dc967.png)



**Does this PR introduce a breaking change?** (check one with "x")
Yes?

User land charts will reverse order.
