### PR TITLE
fix(charts): fix label trimming and clipped svgs

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -243,13 +243,8 @@ export class AppComponent implements OnInit {
       const bubbleEntry = {
         name: country,
         series: [{
-          name: '2010',
-          x: Math.floor(10000 + Math.random() * 20000),
-          y: Math.floor(30 + Math.random() * 70),
-          r: Math.floor(30 + Math.random() * 20),
-        }, {
-          name: '2011',
-          x: Math.floor(10000 + Math.random() * 20000),
+          name: new Date(Math.floor(1473700105009 +  Math.random() * 1000000000)),
+          x: new Date(Math.floor(1473700105009 +  Math.random() * 1000000000)),
           y: Math.floor(30 + Math.random() * 70),
           r: Math.floor(30 + Math.random() * 20),
         }]

--- a/src/bubble-chart/bubble-chart.component.ts
+++ b/src/bubble-chart/bubble-chart.component.ts
@@ -200,7 +200,10 @@ export class BubbleChartComponent extends BaseChartComponent {
       }
     }
 
-    return [yMin, xMax - this.dims.width, yMax - this.dims.height, xMin];
+    xMax = Math.max(xMax - this.dims.width, 0);
+    yMax = Math.max(yMax - this.dims.height, 0);
+
+    return [yMin, xMax, yMax, xMin];
   }
 
   setScales() {

--- a/src/common/base-chart.component.scss
+++ b/src/common/base-chart.component.scss
@@ -1,5 +1,6 @@
 .ngx-charts {
   float: left;
+  overflow: visible;
 
   .circle,
   .bar,

--- a/src/common/trim-label.helper.ts
+++ b/src/common/trim-label.helper.ts
@@ -6,10 +6,11 @@ export function trimLabel(s, max = 16): string {
       return '';
     }
   }
-
+  
+  s = s.trim();
   if(s.length <= max) {
     return s;
   } else {
-    return `${s.slice(0, max).trim()}...`;
+    return `${s.slice(0, max)}...`;
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Tick labels with white space are not properly trimmed.  Some labels are cut off by clipping of SVGs.

**What is the new behavior?**
Tick labels with white space are properly trimmed.  SVGs are no longer clipped.

**Does this PR introduce a breaking change?** (check one with "x")
No

