### PR TITLE
fix: @angular/http is a peer of ngx-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@angular/compiler-cli": "~4.0.1",
     "@angular/core": "~4.0.1",
     "@angular/forms": "~4.0.1",
+    "@angular/http": "^4.0.3",
     "@angular/platform-browser": "~4.0.1",
     "@angular/platform-browser-dynamic": "~4.0.1",
     "@angular/platform-server": "~4.0.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
@angular/http is a peer of ngx-ui, not installed by by ngx-charts


**What is the new behavior?**
@angular/http is a peer of ngx-ui, now installed by by ngx-charts



**Does this PR introduce a breaking change?** (check one with "x")
No
