### PR TITLE
feat(charts): force minimum axis scale

### DIFF
--- a/docs/charts/area-chart-stacked.md
+++ b/docs/charts/area-chart-stacked.md
@@ -32,6 +32,8 @@
 | tooltipDisabled       | boolean     | false         | show or hide the tooltip                                                                                                         |
 | tooltipTemplate       | TemplateRef |               | a custom ng-template to be displayed inside the tooltip when hovering a single point                                             |
 | seriesTooltipTemplate | TemplateRef |               | a custom ng-template to be displayed inside the tooltip when hovering series                                                     |
+| xAxisMinScale         | object      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                                       |
+| yAxisMinScale         | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                                       |
 
 # Outputs
 

--- a/docs/charts/area-chart.md
+++ b/docs/charts/area-chart.md
@@ -32,6 +32,8 @@
 | tooltipDisabled       | boolean     | false         | show or hide the tooltip                                                                                                         |
 | tooltipTemplate       | TemplateRef |               | a custom ng-template to be displayed inside the tooltip when hovering a single point                                             |
 | seriesTooltipTemplate | TemplateRef |               | a custom ng-template to be displayed inside the tooltip when hovering series                                                     |
+| xAxisMinScale         | object      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                                       |
+| yAxisMinScale         | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                                       |
 
 # Outputs
 

--- a/docs/charts/bar-horizontal-2d.md
+++ b/docs/charts/bar-horizontal-2d.md
@@ -30,6 +30,7 @@
 | groupPadding        | number      | 16            | padding between groups in px                                                                                    |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| xAxisMinScale       | number      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bar-horizontal-stacked.md
+++ b/docs/charts/bar-horizontal-stacked.md
@@ -29,6 +29,7 @@
 | barPadding          | number      | 8             | padding between bars in px                                                                                      |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| xAxisMinScale       | number      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bar-horizontal.md
+++ b/docs/charts/bar-horizontal.md
@@ -29,6 +29,7 @@
 | barPadding          | number      | 8             | padding between bars in px                                                                                      |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| xAxisMinScale       | number      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bar-vertical-2d.md
+++ b/docs/charts/bar-vertical-2d.md
@@ -30,6 +30,7 @@
 | groupPadding        | number      | 16            | padding between groups in px                                                                                    |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| yAxisMinScale       | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bar-vertical-stacked.md
+++ b/docs/charts/bar-vertical-stacked.md
@@ -29,6 +29,7 @@
 | barPadding          | number      | 8             | padding between bars in px                                                                                      |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| yAxisMinScale       | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bar-vertical.md
+++ b/docs/charts/bar-vertical.md
@@ -29,6 +29,7 @@
 | barPadding          | number      | 8             | padding between bars in px                                                                                      |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| yAxisMinScale       | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/bubble-chart.md
+++ b/docs/charts/bubble-chart.md
@@ -28,6 +28,8 @@
 | maxRadius           | number      | 10            | maximum bubble radius in px                                                                                     |
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| xAxisMinScale       | object      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                      |
+| yAxisMinScale       | object      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                      |
 
 # Outputs
 

--- a/docs/charts/line-chart.md
+++ b/docs/charts/line-chart.md
@@ -36,6 +36,8 @@
 | referenceLines        | object[]    |               | an array of reference lines to be shown behind the chart. Every reference line should be of format {name, value}                                                                                                                         |
 | showRefLines          | boolean     | false         | show or hide the reference lines                                                                                                                                                                                                         |
 | showRefLabels         | boolean     | true          | show or hide the reference line labels                                                                                                                                                                                                   |
+| xAxisMinScale         | object      |               | force x axis scaling to the provided value (ignored if chart data contains a higher value)                                                                                                                                               |
+| yAxisMinScale         | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                                                                                                                                               |
 
 # Outputs
 

--- a/docs/charts/polar-chart.md
+++ b/docs/charts/polar-chart.md
@@ -28,6 +28,7 @@
 | tooltipDisabled     | boolean     | false         | show or hide the tooltip                                                                                                                                                                                                                  |
 | showSeriesOnHover   | boolean     | true          | show or hide all points on the line on hover                                                                                                                                                                                              |
 | tooltipTemplate     | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                                                                                                                                                   |
+| yAxisMinScale       | number      |               | force y axis scaling to the provided value (ignored if chart data contains a higher value)                                                                                                                                                |
 
 # Outputs
 

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -156,6 +156,8 @@ export class AreaChartStackedComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() roundDomains: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() xAxisMinScale: any;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -294,7 +296,11 @@ export class AreaChartStackedComponent extends BaseChartComponent {
 
     if (this.scaleType === 'time') {
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [new Date(min), new Date(max)];
       this.xSet = [...values].sort((a, b) => {
         const aDate = a.getTime();
@@ -306,7 +312,11 @@ export class AreaChartStackedComponent extends BaseChartComponent {
     } else if (this.scaleType === 'linear') {
       values = values.map(v => Number(v));
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [min, max];
       this.xSet = [...values].sort();
     } else {
@@ -343,7 +353,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
     }
 
     const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
     return [min, max];
   }
 

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -155,6 +155,8 @@ export class AreaChartComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() roundDomains: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() xAxisMinScale: any;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -263,7 +265,11 @@ export class AreaChartComponent extends BaseChartComponent {
 
     if (this.scaleType === 'time') {
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [new Date(min), new Date(max)];
       this.xSet = [...values].sort((a, b) => {
         const aDate = a.getTime();
@@ -275,7 +281,11 @@ export class AreaChartComponent extends BaseChartComponent {
     } else if (this.scaleType === 'linear') {
       values = values.map(v => Number(v));
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [min, max];
       this.xSet = [...values].sort();
     } else {
@@ -298,7 +308,8 @@ export class AreaChartComponent extends BaseChartComponent {
     }
 
     let min = Math.min(...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
+
     if (!this.autoScale) {
       min = Math.min(0, min);
     }

--- a/src/bar-chart/bar-horizontal-2d.component.ts
+++ b/src/bar-chart/bar-horizontal-2d.component.ts
@@ -120,6 +120,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
+  @Input() xAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -239,9 +240,8 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
     }
 
     const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
-
-    return [ min, max ];
+    const max = Math.max(this.xAxisMinScale, ...domain);
+    return [min, max];
   }
 
   groupTransform(group) {

--- a/src/bar-chart/bar-horizontal-stacked.component.ts
+++ b/src/bar-chart/bar-horizontal-stacked.component.ts
@@ -111,6 +111,7 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() xAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -201,9 +202,8 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
     }
 
     const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
-
-    return [ min, max ];
+    const max = Math.max(this.xAxisMinScale, ...domain);
+    return [min, max];
   }
 
   getYScale(): any {

--- a/src/bar-chart/bar-horizontal.component.ts
+++ b/src/bar-chart/bar-horizontal.component.ts
@@ -87,6 +87,7 @@ export class BarHorizontalComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
+  @Input() xAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -153,11 +154,9 @@ export class BarHorizontalComponent extends BaseChartComponent {
 
   getXDomain(): any[] {
     const values = this.results.map(d => d.value);
-
     const min = Math.min(0, ...values);
-    const max = Math.max(...values);
-
-    return [ min, max ];
+    const max = Math.max(this.xAxisMinScale, ...values);
+    return [min, max];
   }
 
   getYDomain(): any[] {

--- a/src/bar-chart/bar-vertical-2d.component.ts
+++ b/src/bar-chart/bar-vertical-2d.component.ts
@@ -118,6 +118,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -232,7 +233,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
     }
 
     const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
     return [min, max];
   }
 

--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -110,6 +110,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -198,7 +199,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
     }
 
     const min = Math.min(0, ...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
     return [min, max];
   }
 

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -87,6 +87,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -155,7 +156,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   getYDomain() {
     const values = this.results.map(d => d.value);
     const min = Math.min(0, ...values);
-    const max = Math.max(...values);
+    const max = Math.max(this.yAxisMinScale, ...values);
     return [min, max];
   }
 

--- a/src/bubble-chart/bubble-chart.component.ts
+++ b/src/bubble-chart/bubble-chart.component.ts
@@ -126,6 +126,8 @@ export class BubbleChartComponent extends BaseChartComponent {
   @Input() schemeType = 'ordinal';
   @Input() legendPosition: string = 'right';
   @Input() tooltipDisabled: boolean = false;
+  @Input() xAxisMinScale: any;
+  @Input() yAxisMinScale: any;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -293,7 +295,7 @@ export class BubbleChartComponent extends BaseChartComponent {
     }
 
     this.xScaleType = getScaleType(values);
-    return getDomain(values, this.xScaleType, this.autoScale);
+    return getDomain(values, this.xScaleType, this.autoScale, this.xAxisMinScale);
   }
 
   getYDomain(): any[] {
@@ -308,7 +310,7 @@ export class BubbleChartComponent extends BaseChartComponent {
     }
 
     this.yScaleType = getScaleType(values);
-    return getDomain(values, this.yScaleType, this.autoScale);
+    return getDomain(values, this.yScaleType, this.autoScale, this.yAxisMinScale);
   }
 
   getRDomain(): number[] {

--- a/src/bubble-chart/bubble-chart.utils.ts
+++ b/src/bubble-chart/bubble-chart.utils.ts
@@ -27,20 +27,29 @@ function isDate(value: any): boolean {
   return false;
 }
 
-export function getDomain(values, scaleType, autoScale): number[] {
+export function getDomain(values, scaleType, autoScale, minScale?): number[] {
     let domain: number[] = [];
 
     if (scaleType === 'time') {
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = minScale
+        ? Math.max(minScale, ...values)
+        : Math.max(...values);
+
       domain = [min, max];
     } else if (scaleType === 'linear') {
       values = values.map(v => Number(v));
       let min = Math.min(...values);
-      const max = Math.max(...values);
+
       if (!autoScale) {
         min = Math.min(0, min);
       }
+
+      const max = minScale
+        ? Math.max(minScale, ...values)
+        : Math.max(...values);
+
       domain = [min, max];
     } else {
       domain = values;

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -181,6 +181,8 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() showRefLines: boolean = false;
   @Input() referenceLines: any;
   @Input() showRefLabels: boolean = true;
+  @Input() xAxisMinScale: any;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -290,7 +292,11 @@ export class LineChartComponent extends BaseChartComponent {
 
     if (this.scaleType === 'time') {
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [new Date(min), new Date(max)];
       this.xSet = [...values].sort((a, b) => {
         const aDate = a.getTime();
@@ -302,7 +308,11 @@ export class LineChartComponent extends BaseChartComponent {
     } else if (this.scaleType === 'linear') {
       values = values.map(v => Number(v));
       const min = Math.min(...values);
-      const max = Math.max(...values);
+
+      const max = this.xAxisMinScale
+        ? Math.max(this.xAxisMinScale, ...values)
+        : Math.max(...values);
+
       domain = [min, max];
       this.xSet = [...values].sort();
     } else {
@@ -336,7 +346,8 @@ export class LineChartComponent extends BaseChartComponent {
     }
 
     let min = Math.min(...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
+
     if (!this.autoScale) {
       min = Math.min(0, min);
     }

--- a/src/polar-chart/polar-chart.component.ts
+++ b/src/polar-chart/polar-chart.component.ts
@@ -147,6 +147,7 @@ export class PolarChartComponent extends BaseChartComponent {
   @Input() tooltipDisabled: boolean = false;
   @Input() showSeriesOnHover: boolean = true;
   @Input() gradient: boolean = false;
+  @Input() yAxisMinScale: number = 0;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -348,7 +349,7 @@ export class PolarChartComponent extends BaseChartComponent {
 
   getYDomain(domain = this.getYValues()): any[] {
     let min = Math.min(...domain);
-    const max = Math.max(...domain);
+    const max = Math.max(this.yAxisMinScale, ...domain);
 
     min = Math.max(0, min);
     if (!this.autoScale) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?**

Fixes: #228 

This PR adds `xAxisMinScale` and `yAxisMinScale` where possible to force axis scaling to the provided value.

If the provided value is smaller than one of the chart data values, it is ignored and axis scaling will use chart data as usual.

Some `xAxisMinScale` and `yAxisMinScale` definitions are set to `any` on purpose, to allow adding dates when using time scale types.

Following chart types have been extended with this feature:

- Vertical Bar Chart
- Horizontal Bar Chart
- Grouped Vertical Bar Chart
- Grouped Horizontal Bar Chart
- Stacked Vertical Bar Chart
- Stacked Horizontal Bar Chart
- Area Chart
- Stacked Area Chart
- Line Chart
- Bubble Chart
- **Polar Chart** (added 9/19/2017)

This PR also includes documentation.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No