### PR TITLE
fix(legend): trauncate to get integers, fixes #360

### DIFF
--- a/src/common/charts/chart.component.ts
+++ b/src/common/charts/chart.component.ts
@@ -103,8 +103,8 @@ export class ChartComponent implements OnChanges {
 
     const chartColumns = 12 - legendColumns;
 
-    this.chartWidth = Math.round(this.view[0] * chartColumns / 12.0);
-    this.legendWidth = Math.round(this.view[0] * legendColumns / 12.0);
+    this.chartWidth = ~~(this.view[0] * chartColumns / 12.0);
+    this.legendWidth = ~~(this.view[0] * legendColumns / 12.0);
   }
 
   getLegendType(): string {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The legend on a line-chart component is misplaced on the bottom of the chart on some resolutions. Rounding errors on the `legendWidth` are the issue here.

**What is the new behavior?**

Fixes: #360

Truncate `chartWidth` and `legendWidth` instead of rounding it.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No