### PR TITLE
feature(number-cards): disable pointer if no click events are attached

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -452,8 +452,7 @@
           emptyColor="#1e222e"
           [results]="statusData"
           [valueFormatting]="statusValueFormat"
-          [labelFormatting]="statusLabelFormat"
-          (select)="select($event)">
+          [labelFormatting]="statusLabelFormat">
         </ngx-charts-number-card>
       </div>
       <ngx-charts-gauge

--- a/src/number-card/card.component.scss
+++ b/src/number-card/card.component.scss
@@ -1,9 +1,5 @@
 ngx-charts-number-card {
   .cell {
-    .card, .cardBand {
-      cursor: pointer;
-    }
-
     .trimmed-label {
       font-size: 12px;
       pointer-events: none;
@@ -24,6 +20,12 @@ ngx-charts-number-card {
 
     .value-text {
       pointer-events: none;
+    }
+  }
+
+  .number-card.clickable .cell {
+    .card, .card-band {
+      cursor: pointer;
     }
   }
 }

--- a/src/number-card/number-card.component.ts
+++ b/src/number-card/number-card.component.ts
@@ -15,7 +15,7 @@ import { gridLayout, gridSize } from '../common/grid-layout.helper';
     <ngx-charts-chart
       [view]="[width, height]"
       [showLegend]="false">
-      <svg:g [attr.transform]="transform" class="number-card chart">
+      <svg:g [attr.transform]="transform" class="number-card chart" [class.clickable]="clickable">
         <svg:g ngx-charts-card-series
           [colors]="colors"
           [cardColor]="cardColor"
@@ -57,6 +57,10 @@ export class NumberCardComponent extends BaseChartComponent {
   margin = [10, 10, 10, 10];
 
   backgroundCards: any[];
+
+  get clickable() {
+    return !!this.select.observers.length;
+  }
 
   update(): void {
     super.update();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Feature

**What is the current behavior?** (You can also link to an open issue here)
Number cards show a "click" pointer even if no select listeners are attached.

**What is the new behavior?**
Number cards only show a "click" pointer even if no select listeners are attached.


**Does this PR introduce a breaking change?** (check one with "x")
No

**Other information**:
