### PR TITLE
Override defaults per chart type, based on chartTypes.ts

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -287,39 +287,26 @@ export class AppComponent implements OnInit {
     this.chartType = chartSelector = chartSelector.replace('/', '');
     this.location.replaceState(this.chartType);
 
-    this.linearScale = this.chartType === 'line-chart' ||
-      this.chartType === 'line-chart-with-ranges' ||
-      this.chartType === 'area-chart' ||
-      this.chartType === 'area-chart-normalized' ||
-      this.chartType === 'area-chart-stacked';
-
-    if (this.chartType === 'bubble-chart') {
-      this.xAxisLabel = 'Census Date';
-      this.yAxisLabel = 'Life expectancy [years]';
-    } else {
-      this.yAxisLabel = 'GDP Per Capita';
-      this.xAxisLabel = 'Country';
+    for (const group of this.chartGroups) {
+      this.chart = group.charts.find(x => x.selector === chartSelector);
+      if (this.chart) break;
     }
 
-    if (this.chartType === 'calendar') {
-      this.width = 1100;
-      this.height = 200;
-    } else {
-      this.width = 700;
-      this.height = 300;
+    this.linearScale = false;
+    this.yAxisLabel = 'GDP Per Capita';
+    this.xAxisLabel = 'Country';
+
+    this.width = 700;
+    this.height = 300;
+
+    for (const k in this.chart.defaults){
+      if (this.chart.defaults.hasOwnProperty(k)) {
+        this[k] = this.chart.defaults[k];
+      }
     }
 
     if (!this.fitContainer) {
       this.applyDimensions();
-    }
-
-    for (const group of this.chartGroups) {
-      for (const chart of group.charts) {
-        if (chart.selector === chartSelector) {
-          this.chart = chart;
-          return;
-        }
-      }
     }
   }
 

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -299,7 +299,7 @@ export class AppComponent implements OnInit {
     this.width = 700;
     this.height = 300;
 
-    for (const k in this.chart.defaults){
+    for (const k in this.chart.defaults) {
       if (this.chart.defaults.hasOwnProperty(k)) {
         this[k] = this.chart.defaults[k];
       }

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -20,7 +20,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'showGridLines', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Country',
+          xAxisLabel: 'GDP Per Capita',
+        }
       },
       {
         name: 'Grouped Vertical Bar Chart',
@@ -40,7 +44,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding', 'groupPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'showGridLines', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Country',
+          xAxisLabel: 'GDP Per Capita',
+        }
       },
       {
         name: 'Stacked Vertical Bar Chart',
@@ -60,7 +68,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'showGridLines', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Country',
+          xAxisLabel: 'GDP Per Capita',
+        }
       },
       {
         name: 'Normalized Vertical Bar Chart',
@@ -70,7 +82,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'showGridLines', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Normalized GDP Per Capita',
+          xAxisLabel: 'Country',
+        }
       },
       {
         name: 'Normalized Horizontal Bar Chart',
@@ -80,7 +96,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'showGridLines', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Country',
+          xAxisLabel: 'Normalized GDP Per Capita',
+        }
       }
     ]
   },
@@ -122,7 +142,12 @@ const chartGroups = [
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'rangeFillOpacity', 'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'GDP Per Capita',
+          xAxisLabel: 'Census Date',
+          linearScale: true
+        }
       },
       {
         name: 'Area Chart',
@@ -133,7 +158,12 @@ const chartGroups = [
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'GDP Per Capita',
+          xAxisLabel: 'Census Date',
+          linearScale: true
+        }
       },
       {
         name: 'Stacked Area Chart',
@@ -144,7 +174,12 @@ const chartGroups = [
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'GDP Per Capita',
+          xAxisLabel: 'Census Date',
+          linearScale: true
+        }
       },
       {
         name: 'Normalized Area Chart',
@@ -155,7 +190,12 @@ const chartGroups = [
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'roundDomains', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Normalized GDP Per Capita',
+          xAxisLabel: 'Census Date',
+          linearScale: true
+        }
       },
     ]
   },
@@ -170,7 +210,11 @@ const chartGroups = [
           'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'showLegend', 'legendTitle',
           'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel', 'showGridLines',
           'roundDomains', 'autoScale', 'minRadius', 'maxRadius', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          xAxisLabel: 'Census Date',
+          yAxisLabel: 'Life expectancy [years]'
+        }
       },
       {
         name: 'Force Directed Graph',
@@ -186,7 +230,11 @@ const chartGroups = [
           'colorScheme', 'showXAxis', 'showYAxis', 'gradient', 'showLegend',
           'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
           'innerPadding', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          yAxisLabel: 'Census Date',
+          cAxisLabel: 'Country'
+        }
       },
       {
         name: 'Tree Map',
@@ -227,7 +275,11 @@ const chartGroups = [
         options: [
           'colorScheme', 'showXAxis', 'showYAxis', 'gradient', 'showLegend',
           'innerPadding', 'tooltipDisabled'
-        ]
+        ],
+        defaults: {
+          width: 1100,
+          height: 200
+        }
       },
       {
         name: 'Number Cards - Status',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Demo

**What is the new behavior?**
Default options are now set per chart type in `chartTypes.ts`.


**Does this PR introduce a breaking change?** (check one with "x")
No

**Other information**:
Will likely need to be rebased after PR #380.
