### PR TITLE
Fix Gauge: add type to valueFormatting parameter (#335)

### DIFF
--- a/release/gauge/gauge-arc.component.d.ts
+++ b/release/gauge/gauge-arc.component.d.ts
@@ -7,7 +7,7 @@ export declare class GaugeArcComponent {
     colors: ColorHelper;
     isActive: boolean;
     tooltipDisabled: boolean;
-    valueFormatting: (value) => string;
+    valueFormatting: (value: any) => string;
     select: EventEmitter<{}>;
     activate: EventEmitter<{}>;
     deactivate: EventEmitter<{}>;

--- a/release/gauge/gauge.component.d.ts
+++ b/release/gauge/gauge.component.d.ts
@@ -18,7 +18,7 @@ export declare class GaugeComponent extends BaseChartComponent implements AfterV
     activeEntries: any[];
     axisTickFormatting: any;
     tooltipDisabled: boolean;
-    valueFormatting: (value) => string;
+    valueFormatting: (value: any) => string;
     margin: any[];
     activate: EventEmitter<any>;
     deactivate: EventEmitter<any>;


### PR DESCRIPTION
What kind of change does this PR introduce? (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code
- [ ] style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

What is the current behavior? (You can also link to an open issue here)
Error in [at-loader] valueFormatting parameter 'value' implicitly has an 'any' type in .

What is the new behavior?
No error and valueFormatting ’value’ parameter is declared ‘any’ type.

Does this PR introduce a breaking change? (check one with "x")
No