### PR TITLE
update for d3-color version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@swimlane/ngx-ui": "^14.2.4",
     "@types/d3-array": "1.1.0",
     "@types/d3-brush": "1.0.6",
-    "@types/d3-color": "1.0.4",
+    "@types/d3-color": "1.0.3",
     "@types/d3-force": "1.0.6",
     "@types/d3-format": "1.1.0",
     "@types/d3-hierarchy": "1.1.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

w/ 5.2.0, on build, I would get this message:

```
  Cannot find module '@types/d3-color'.
```

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

It looks like d3-color is only at 1.0.3:

  https://www.npmjs.com/package/d3-color

Maybe this isn't all we need to do, but I think it'll help, at least