### PR TITLE
fix(color-utils): remove RGBColor type from util file

### DIFF
--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -1,5 +1,4 @@
 import * as d3_color from 'd3-color';
-import { RGBColor } from '@types/d3-color';
 
 /**
  * Converts a hex to RGB
@@ -8,7 +7,7 @@ import { RGBColor } from '@types/d3-color';
  * @param {string} hex
  * @returns {*}
  */
-export function hexToRgb(value: string): RGBColor {
+export function hexToRgb(value: string): any {
   // deprecated, use d3.color()
   return d3_color.rgb(value);
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Importing a type from `@types/d3-color` causes errors.


**What is the new behavior?**
Removed type importing, using `any`.


**Does this PR introduce a breaking change?** (check one with "x")
No

