### PR TITLE
Feature: Disable tooltip tag creation in case of tooltipDisabled

### DIFF
--- a/src/bar-chart/series-horizontal.component.ts
+++ b/src/bar-chart/series-horizontal.component.ts
@@ -39,8 +39,8 @@ import {
       (deactivate)="deactivate.emit($event)"
       ngx-tooltip
       [tooltipDisabled]="tooltipDisabled"
-      [tooltipPlacement]="'top'"
-      [tooltipType]="'tooltip'"
+      [tooltipPlacement]="tooltipPlacement"
+      [tooltipType]="tooltipType"
       [tooltipTitle]="tooltipTemplate ? undefined : bar.tooltipText"
       [tooltipTemplate]="tooltipTemplate"
       [tooltipContext]="bar.data">
@@ -79,11 +79,15 @@ export class SeriesHorizontal implements OnChanges {
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();
 
+  tooltipPlacement: string;
+  tooltipType: string;
+
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
   }
 
   update(): void {
+    this.updateTooltipSettings();
     let d0 = 0;
     let total;
     if (this.type === 'normalized') {
@@ -163,13 +167,18 @@ export class SeriesHorizontal implements OnChanges {
         bar.data.series = this.seriesName;
       }
 
-      bar.tooltipText = `
+      bar.tooltipText = this.tooltipDisabled ? undefined : `
         <span class="tooltip-label">${tooltipLabel}</span>
         <span class="tooltip-val">${value.toLocaleString()}</span>
       `;
 
       return bar;
     });
+  }
+
+  updateTooltipSettings() {
+    this.tooltipPlacement = this.tooltipDisabled ? undefined : 'top';
+    this.tooltipType =  this.tooltipDisabled ? undefined : 'tooltip';
   }
 
   isActive(entry): boolean {

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -38,8 +38,8 @@ import { formatLabel } from '../common/label.helper';
       (deactivate)="deactivate.emit($event)"
       ngx-tooltip
       [tooltipDisabled]="tooltipDisabled"
-      [tooltipPlacement]="'top'"
-      [tooltipType]="'tooltip'"
+      [tooltipPlacement]="tooltipPlacement"
+      [tooltipType]="tooltipType"
       [tooltipTitle]="tooltipTemplate ? undefined : bar.tooltipText"
       [tooltipTemplate]="tooltipTemplate"
       [tooltipContext]="bar.data">
@@ -75,6 +75,9 @@ export class SeriesVerticalComponent implements OnChanges {
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();
 
+  tooltipPlacement: string;
+  tooltipType: string;
+  
   bars: any;
   x: any;
   y: any;
@@ -84,6 +87,7 @@ export class SeriesVerticalComponent implements OnChanges {
   }
 
   update(): void {
+    this.updateTooltipSettings();
     let width;
     if (this.series.length) {
       width = this.xScale.bandwidth();
@@ -171,13 +175,18 @@ export class SeriesVerticalComponent implements OnChanges {
         bar.data.series = this.seriesName;
       }
 
-      bar.tooltipText = `
+      bar.tooltipText = this.tooltipDisabled ? undefined : `
         <span class="tooltip-label">${tooltipLabel}</span>
         <span class="tooltip-val">${value.toLocaleString()}</span>
       `;
 
       return bar;
     });
+  }
+
+  updateTooltipSettings() {
+    this.tooltipPlacement = this.tooltipDisabled ? undefined : 'top';
+    this.tooltipType =  this.tooltipDisabled ? undefined : 'tooltip';
   }
 
   isActive(entry): boolean {

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -80,6 +80,7 @@ import { id } from '../utils/id';
             />
           </svg:g>
           <svg:g ngx-charts-area-tooltip
+            *ngIf="!tooltipDisabled"
             [xSet]="xSet"
             [xScale]="xScale"
             [yScale]="yScale"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Takes care of #414. This implementation will take care of not creating tooltip svgs in case tooltips are set as false. This has been implemented for all the Bar Charts & Line chart.

**What is the new behavior?**
- Modified Bar & Line Chart implementation to **NOT** to trigger tooltip creation in case of `tooltipDisabled`.
- Usage in demo/app.html stays the same, internal implementation is modified.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
