### PR TITLE
Log axis

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -12,6 +12,9 @@
         [gradient]="gradient"
         [xAxis]="showXAxis"
         [yAxis]="showYAxis"
+        [yAxisScale]="yAxisScale"
+        [yDomainMin]="yDomainMin"
+        [yDomainMax]="yDomainMax"
         [legend]="showLegend"
         [legendTitle]="legendTitle"
         [showXAxisLabel]="showXAxisLabel"
@@ -247,6 +250,8 @@
         [xAxis]="showXAxis"
         [yAxis]="showYAxis"
         [yAxisScale]="yAxisScale"
+        [yDomainMin]="yDomainMin"
+        [yDomainMax]="yDomainMax"
         [showXAxisLabel]="showXAxisLabel"
         [showYAxisLabel]="showYAxisLabel"
         [xAxisLabel]="xAxisLabel"
@@ -992,6 +997,17 @@
             {{scaleType}}
           </option>
         </select>
+      </div>
+      <div *ngIf="chart.options.includes('yDomainMin')">
+        <label>Domain Limits</label>
+        <input type="checkbox" [checked]="domainLimits" (change)="toggleDomainLimits($event.target.checked)">
+        <label>Y axis min:</label><br />
+        <input type="number" [(ngModel)]="_yDomainMin"><br />
+      </div>
+
+      <div *ngIf="chart.options.includes('yDomainMax')">
+        <label>Y axis max:</label><br />
+        <input type="number" [(ngModel)]="_yDomainMax"><br />
       </div>
       <div *ngIf="chart.options.includes('min')">
         <label>Min value:</label><br />

--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -246,6 +246,7 @@
         [gradient]="gradient"
         [xAxis]="showXAxis"
         [yAxis]="showYAxis"
+        [yAxisScale]="yAxisScale"
         [showXAxisLabel]="showXAxisLabel"
         [showYAxisLabel]="showYAxisLabel"
         [xAxisLabel]="xAxisLabel"
@@ -979,6 +980,16 @@
           (ngModelChange)="closedCurve = getInterpolationType($event)">
           <option *ngFor="let interpolationType of closedInterpolationTypes" [value]="interpolationType">
             {{interpolationType}}
+          </option>
+        </select>
+      </div>
+      <div *ngIf="chart.options.includes('yAxisScale')">
+        <label>Y Axis Scale</label>
+        <select
+          [ngModel]="yAxisScale"
+          (ngModelChange)="setYAxisScale($event)">
+          <option *ngFor="let scaleType of scaleTypes" [value]="scaleType">
+            {{scaleType}}
           </option>
         </select>
       </div>

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -59,6 +59,7 @@ export class AppComponent implements OnInit {
   width: number = 700;
   height: number = 300;
   fitContainer: boolean = false;
+  domainLimits: boolean = false;
 
   // options
   showXAxis = true;
@@ -99,6 +100,17 @@ export class AppComponent implements OnInit {
     'Step Before': shape.curveStepBefore,
     default: shape.curveLinear
   };
+
+  _yDomainMin = 1000;
+  _yDomainMax = 10000;
+  yDomainMin: any;
+  yDomainMax: any;
+
+  // axis scales
+  yAxisScale = 'linear';
+  scaleTypes = [
+    'linear', 'log'
+  ];
 
   // line interpolation
   curveType: string = 'Linear';
@@ -374,6 +386,23 @@ export class AppComponent implements OnInit {
     }
   }
 
+  applyDomainLimits(event) {
+    this.yDomainMin = this._yDomainMin;
+    this.yDomainMax = this._yDomainMax;
+  }
+
+  toggleDomainLimits(event) {
+    this.domainLimits = event;
+
+    if (!this.domainLimits) {
+      this.yDomainMax = undefined;
+      this.yDomainMin = undefined;
+    } else {
+      this.yDomainMax = this._yDomainMax;
+      this.yDomainMin = this._yDomainMin;
+    }
+  }
+
   selectChart(chartSelector) {
     this.chartType = chartSelector = chartSelector.replace('/', '');
     this.location.replaceState(this.chartType);
@@ -403,6 +432,17 @@ export class AppComponent implements OnInit {
 
   getInterpolationType(curveType) {
     return this.curves[curveType] || this.curves['default'];
+  }
+
+  setYAxisScale(transformType) {
+    console.log(transformType);
+
+    if (transformType === 'linear') {
+      this.yAxisScale = 'linear';
+    }
+    if (transformType === 'log') {
+      this.yAxisScale = 'log';
+    }
   }
 
   setColorScheme(name) {

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -435,8 +435,6 @@ export class AppComponent implements OnInit {
   }
 
   setYAxisScale(transformType) {
-    console.log(transformType);
-
     if (transformType === 'linear') {
       this.yAxisScale = 'linear';
     }

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -138,7 +138,7 @@ const chartGroups = [
         selector: 'line-chart',
         inputFormat: 'multiSeries',
         options: [
-          'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient',
+          'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'yAxisScale', 'gradient',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'rangeFillOpacity', 'roundDomains', 'tooltipDisabled', 'showRefLines',

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -7,9 +7,9 @@ const chartGroups = [
         selector: 'bar-vertical',
         inputFormat: 'singleSeries',
         options: [
-          'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'gradient', 'barPadding',
+          'colorScheme', 'schemeType', 'showXAxis', 'showYAxis', 'yAxisScale', 'gradient', 'barPadding',
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges'
+          'showGridLines', 'roundDomains', 'tooltipDisabled', 'roundEdges', 'yDomainMin', 'yDomainMax'
         ]
       },
       {
@@ -142,7 +142,7 @@ const chartGroups = [
           'showLegend', 'legendTitle', 'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel',
           'yAxisLabel', 'autoScale', 'timeline', 'showGridLines', 'curve',
           'rangeFillOpacity', 'roundDomains', 'tooltipDisabled', 'showRefLines',
-          'referenceLines', 'showRefLabels'
+          'referenceLines', 'showRefLabels', 'yDomainMin', 'yDomainMax'
         ],
         defaults: {
           yAxisLabel: 'GDP Per Capita',

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -159,7 +159,7 @@ export class BarVerticalComponent extends BaseChartComponent {
       }
 
       scale = scaleLog()
-        .range([this.dims.height, min])
+        .range([this.dims.height, 0])
         .domain(this.yDomain);
 
       scale.clamp(true);

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -119,13 +119,9 @@ export class SeriesVerticalComponent implements OnChanges {
       };
 
       if (this.type === 'standard') {
-        console.log('here');
-        console.log(this.yScale(value));
-        console.log(this.yScale(0));
         bar.height = Math.abs(this.yScale(value) - this.yScale(this.yScale.domain()[0]));
         bar.x = this.xScale(label);
 
-        console.log(value);
         if (value < 0) {
           bar.y = this.yScale(0);
         } else {

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -119,9 +119,13 @@ export class SeriesVerticalComponent implements OnChanges {
       };
 
       if (this.type === 'standard') {
-        bar.height = Math.abs(this.yScale(value) - this.yScale(0));
+        console.log('here');
+        console.log(this.yScale(value));
+        console.log(this.yScale(0));
+        bar.height = Math.abs(this.yScale(value) - this.yScale(this.yScale.domain()[0]));
         bar.x = this.xScale(label);
 
+        console.log(value);
         if (value < 0) {
           bar.y = this.yScale(0);
         } else {

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -165,7 +165,6 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() yDomainMax;
   @Input() xAxisLabel;
   @Input() yAxisLabel;
-  @Input() xAxisScale;
   @Input() yAxisScale;
   @Input() autoScale;
   @Input() timeline;

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -17,7 +17,7 @@ import {
   transition
 } from '@angular/animations';
 import { PathLocationStrategy } from '@angular/common';
-import { scaleLinear, scaleTime, scalePoint } from 'd3-scale';
+import { scaleLinear, scaleLog, scaleTime, scalePoint } from 'd3-scale';
 import { curveLinear } from 'd3-shape';
 
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
@@ -46,92 +46,92 @@ import { id } from '../utils/id';
       </svg:defs>
       <svg:g [attr.transform]="transform" class="line-chart chart">
         <svg:g ngx-charts-x-axis
-          *ngIf="xAxis"
-          [xScale]="xScale"
-          [dims]="dims"
-          [showGridLines]="showGridLines"
-          [showLabel]="showXAxisLabel"
-          [labelText]="xAxisLabel"
-          [tickFormatting]="xAxisTickFormatting"
-          (dimensionsChanged)="updateXAxisHeight($event)">
+               *ngIf="xAxis"
+               [xScale]="xScale"
+               [dims]="dims"
+               [showGridLines]="showGridLines"
+               [showLabel]="showXAxisLabel"
+               [labelText]="xAxisLabel"
+               [tickFormatting]="xAxisTickFormatting"
+               (dimensionsChanged)="updateXAxisHeight($event)">
         </svg:g>
         <svg:g ngx-charts-y-axis
-          *ngIf="yAxis"
-          [yScale]="yScale"
-          [dims]="dims"
-          [showGridLines]="showGridLines"
-          [showLabel]="showYAxisLabel"
-          [labelText]="yAxisLabel"
-          [tickFormatting]="yAxisTickFormatting"
-          [referenceLines]="referenceLines"
-          [showRefLines]="showRefLines"
-          [showRefLabels]="showRefLabels"
-          (dimensionsChanged)="updateYAxisWidth($event)">
+               *ngIf="yAxis"
+               [yScale]="yScale"
+               [dims]="dims"
+               [showGridLines]="showGridLines"
+               [showLabel]="showYAxisLabel"
+               [labelText]="yAxisLabel"
+               [tickFormatting]="yAxisTickFormatting"
+               [referenceLines]="referenceLines"
+               [showRefLines]="showRefLines"
+               [showRefLabels]="showRefLabels"
+               (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
         <svg:g [attr.clip-path]="clipPath">
           <svg:g *ngFor="let series of results; trackBy:trackBy" [@animationState]="'active'">
             <svg:g ngx-charts-line-series
-              [xScale]="xScale"
-              [yScale]="yScale"
-              [colors]="colors"
-              [data]="series"
-              [activeEntries]="activeEntries"
-              [scaleType]="scaleType"
-              [curve]="curve"
-              [rangeFillOpacity]="rangeFillOpacity"
-              [hasRange]="hasRange"
+                   [xScale]="xScale"
+                   [yScale]="yScale"
+                   [colors]="colors"
+                   [data]="series"
+                   [activeEntries]="activeEntries"
+                   [scaleType]="xScaleType"
+                   [curve]="curve"
+                   [rangeFillOpacity]="rangeFillOpacity"
+                   [hasRange]="hasRange"
             />
           </svg:g>
           <svg:g ngx-charts-area-tooltip
-            *ngIf="!tooltipDisabled"
-            [xSet]="xSet"
-            [xScale]="xScale"
-            [yScale]="yScale"
-            [results]="results"
-            [height]="dims.height"
-            [colors]="colors"
-            [tooltipDisabled]="tooltipDisabled"
-            [tooltipTemplate]="seriesTooltipTemplate"
-            (hover)="updateHoveredVertical($event)"
+                 *ngIf="!tooltipDisabled"
+                 [xSet]="xSet"
+                 [xScale]="xScale"
+                 [yScale]="yScale"
+                 [results]="results"
+                 [height]="dims.height"
+                 [colors]="colors"
+                 [tooltipDisabled]="tooltipDisabled"
+                 [tooltipTemplate]="seriesTooltipTemplate"
+                 (hover)="updateHoveredVertical($event)"
           />
           <svg:g *ngFor="let series of results">
             <svg:g ngx-charts-circle-series
-              [xScale]="xScale"
-              [yScale]="yScale"
-              [colors]="colors"
-              [data]="series"
-              [scaleType]="scaleType"
-              [visibleValue]="hoveredVertical"
-              [activeEntries]="activeEntries"
-              [tooltipDisabled]="tooltipDisabled"
-              [tooltipTemplate]="tooltipTemplate"
-              (select)="onClick($event, series)"
-              (activate)="onActivate($event)"
-              (deactivate)="onDeactivate($event)"
+                   [xScale]="xScale"
+                   [yScale]="yScale"
+                   [colors]="colors"
+                   [data]="series"
+                   [scaleType]="xScaleType"
+                   [visibleValue]="hoveredVertical"
+                   [activeEntries]="activeEntries"
+                   [tooltipDisabled]="tooltipDisabled"
+                   [tooltipTemplate]="tooltipTemplate"
+                   (select)="onClick($event, series)"
+                   (activate)="onActivate($event)"
+                   (deactivate)="onDeactivate($event)"
             />
           </svg:g>
         </svg:g>
       </svg:g>
       <svg:g ngx-charts-timeline
-        *ngIf="timeline && scaleType === 'time'"
-        [attr.transform]="timelineTransform"
-        [results]="results"
-        [view]="[timelineWidth, height]"
-        [height]="timelineHeight"
-        [scheme]="scheme"
-        [customColors]="customColors"
-        [scaleType]="scaleType"
-        [legend]="legend"
-        (onDomainChange)="updateDomain($event)">
+             *ngIf="timeline && xScaleType === 'time'"
+             [attr.transform]="timelineTransform"
+             [results]="results"
+             [view]="[timelineWidth, height]"
+             [height]="timelineHeight"
+             [scheme]="scheme"
+             [customColors]="customColors"
+             [scaleType]="xScaleType"
+             [legend]="legend"
+             (onDomainChange)="updateDomain($event)">
         <svg:g *ngFor="let series of results; trackBy:trackBy">
           <svg:g ngx-charts-line-series
-            [xScale]="timelineXScale"
-            [yScale]="timelineYScale"
-            [colors]="colors"
-            [data]="series"
-            [scaleType]="scaleType"
-            [curve]="curve"
-            [hasRange]="hasRange"
+                 [xScale]="timelineXScale"
+                 [yScale]="timelineYScale"
+                 [colors]="colors"
+                 [data]="series"
+                 [scaleType]="xScaleType"
+                 [curve]="curve"
+                 [hasRange]="hasRange"
           />
         </svg:g>
       </svg:g>
@@ -161,8 +161,12 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() yAxis;
   @Input() showXAxisLabel;
   @Input() showYAxisLabel;
+  @Input() yDomainMin;
+  @Input() yDomainMax;
   @Input() xAxisLabel;
   @Input() yAxisLabel;
+  @Input() xAxisScale;
+  @Input() yAxisScale;
   @Input() autoScale;
   @Input() timeline;
   @Input() gradient: boolean;
@@ -194,7 +198,7 @@ export class LineChartComponent extends BaseChartComponent {
   yScale: any;
   xScale: any;
   colors: ColorHelper;
-  scaleType: string;
+  xScaleType: string;
   transform: string;
   clipPath: string;
   clipPathId: string;
@@ -288,14 +292,14 @@ export class LineChartComponent extends BaseChartComponent {
       }
     }
 
-    this.scaleType = this.getScaleType(values);
+    this.xScaleType = this.getXScaleType(values);
     let domain = [];
 
-    if (this.scaleType === 'time') {
+    if (this.xScaleType === 'time') {
       const min = Math.min(...values);
       const max = Math.max(...values);
       domain = [min, max];
-    } else if (this.scaleType === 'linear') {
+    } else if (this.xScaleType === 'linear') {
       values = values.map(v => Number(v));
       const min = Math.min(...values);
       const max = Math.max(...values);
@@ -309,20 +313,20 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getYDomain(): any[] {
+    // this.yScaleType = this.getYScaleType();
     const domain = [];
+
     for (const results of this.results) {
       for (const d of results.series){
         if (domain.indexOf(d.value) < 0) {
           domain.push(d.value);
         }
         if (d.min !== undefined) {
-          this.hasRange = true;
           if (domain.indexOf(d.min) < 0) {
             domain.push(d.min);
           }
         }
         if (d.max !== undefined) {
-          this.hasRange = true;
           if (domain.indexOf(d.max) < 0) {
             domain.push(d.max);
           }
@@ -331,9 +335,16 @@ export class LineChartComponent extends BaseChartComponent {
     }
 
     let min = Math.min(...domain);
-    const max = Math.max(...domain);
+    let max = Math.max(...domain);
     if (!this.autoScale) {
       min = Math.min(0, min);
+    }
+
+    if ( typeof(this.yDomainMin) !== 'undefined') {
+      min = this.yDomainMin;
+    }
+    if ( typeof(this.yDomainMax) !== 'undefined') {
+      max = this.yDomainMax;
     }
 
     return [min, max];
@@ -346,11 +357,11 @@ export class LineChartComponent extends BaseChartComponent {
   getXScale(domain, width): any {
     let scale;
 
-    if (this.scaleType === 'time') {
+    if (this.xScaleType === 'time') {
       scale = scaleTime()
         .range([0, width])
         .domain(domain);
-    } else if (this.scaleType === 'linear') {
+    } else if (this.xScaleType === 'linear') {
       scale = scaleLinear()
         .range([0, width])
         .domain(domain);
@@ -358,7 +369,7 @@ export class LineChartComponent extends BaseChartComponent {
       if (this.roundDomains) {
         scale = scale.nice();
       }
-    } else if (this.scaleType === 'ordinal') {
+    } else if (this.xScaleType === 'ordinal') {
       scale = scalePoint()
         .range([0, width])
         .padding(0.1)
@@ -369,14 +380,22 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getYScale(domain, height): any {
-    const scale = scaleLinear()
-      .range([height, 0])
-      .domain(domain);
+    let scale;
+
+    if (typeof(this.yAxisScale) === 'undefined' || this.yAxisScale === 'linear') {
+      scale = scaleLinear()
+        .range([height, 0])
+        .domain(domain);
+    } else if (this.yAxisScale === 'log') {
+      scale = scaleLog()
+        .range([height, 0])
+        .domain(domain);
+    }
 
     return this.roundDomains ? scale.nice() : scale;
   }
 
-  getScaleType(values): string {
+  getXScaleType(values): string {
     let date = true;
     let num = true;
 
@@ -393,6 +412,13 @@ export class LineChartComponent extends BaseChartComponent {
     if (date) return 'time';
     if (num) return 'linear';
     return 'ordinal';
+  }
+
+  getYScaleType(): string {
+    if ( typeof(this.yAxisScale) !== 'undefined' && this.yAxisScale === 'log' ) {
+      return 'log';
+    }
+    return 'linear';
   }
 
   isDate(value): boolean {

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -313,7 +313,6 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getYDomain(): any[] {
-    // this.yScaleType = this.getYScaleType();
     const domain = [];
 
     for (const results of this.results) {
@@ -391,7 +390,6 @@ export class LineChartComponent extends BaseChartComponent {
         .range([height, 0])
         .domain(domain);
     }
-
     return this.roundDomains ? scale.nice() : scale;
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#450 (has Accept PR set)

Log scale were not implemented for line chart.

**What is the new behavior?**
This pull request implements log-scale axes for line charts and vertical bar charts. Both of these charts have the new Input strings yAxisScale, yDomainMin, yDomainMax.

yAxisScale can take on 'linear' or 'log' for linear and log scaling respectively. If yAxisScale is left unset, 'linear' is assumed by default.

yDomainMin and yDomainMax are set to values for min and max of the domain.

The three options were added to the demo.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
yDomainMin and yDomainMax were included as these are needed in order to make the log scale useful and cosmetically appealing. 

Several other charts could use the same patterns for implementing log scale. Other scales, for instance d3.scalePower(), could also be implemented using the same techniques.