### PR TITLE
Remove patch numbers from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,10 +74,10 @@
   },
   "homepage": "https://github.com/swimlane/ngx-charts#readme",
   "peerDependencies": {
-    "@angular/common": "^4.2.5",
-    "@angular/core": "^4.2.5",
-    "d3": "^4.9.1",
-    "rxjs": "^5.0.3"
+    "@angular/common": "^4.2.x",
+    "@angular/core": "^4.2.x",
+    "d3": "^4.9.x",
+    "rxjs": "^5.0.x"
   },
   "devDependencies": {
     "@angular/animations": "^4.2.5",


### PR DESCRIPTION
Close #477

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Removed patch numbers from peer dependencies in order to make them more lenient.

**What is the current behaviour?** (You can also link to an open issue here)
Currently these strict peer dependencies make it difficult for consumers who may be locked to specific versions of the dependencies. 

**What is the new behaviour?**
NPM resolution is more lenient, less warnings, and shrinkwrap doesn't break in npm `4.6.x`. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: