### PR TITLE
Fix bug: Tooltip not appearing for certain points

### DIFF
--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -334,7 +334,8 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
       const min = Math.min(...values);
       const max = Math.max(...values);
       domain = [min, max];
-      this.xSet = [...values].sort();
+      // Use compare function to sort numbers numerically
+      this.xSet = [...values].sort((a, b) => (a - b));
     } else {
       domain = values;
       this.xSet = values;

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -308,7 +308,8 @@ export class AreaChartStackedComponent extends BaseChartComponent {
       const min = Math.min(...values);
       const max = Math.max(...values);
       domain = [min, max];
-      this.xSet = [...values].sort();
+      // Use compare function to sort numbers numerically
+      this.xSet = [...values].sort((a, b) => (a - b));
     } else {
       domain = values;
       this.xSet = values;

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -277,7 +277,8 @@ export class AreaChartComponent extends BaseChartComponent {
       const min = Math.min(...values);
       const max = Math.max(...values);
       domain = [min, max];
-      this.xSet = [...values].sort();
+      // Use compare function to sort numbers numerically
+      this.xSet = [...values].sort((a, b) => (a - b));
     } else {
       domain = values;
       this.xSet = values;

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -304,7 +304,8 @@ export class LineChartComponent extends BaseChartComponent {
       const min = Math.min(...values);
       const max = Math.max(...values);
       domain = [min, max];
-      this.xSet = [...values].sort();
+      // Use compare function to sort numbers numerically
+      this.xSet = [...values].sort((a, b) => (a - b));
     } else {
       domain = values;
       this.xSet = values;


### PR DESCRIPTION
This fixes an issue where the tooltip would not appear for certain data
points. I had thirty data points in a line chart, and the tooltip was
working for points 1 and 10, but 2-9 were being skipped over. Looking
further, I noticed that the array of points along the x axis was not being
sorted in the correct order. The numbers were being sorted in
alphabetical order (which explains why 10 came after 1), so I added a
compare function in the related sorts to sort the numbers in xSet
numerically.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When using a line chart or are chart with the linear scale type, if there are
more than 10 data points, the tooltip will not appear for certain points.

**What is the new behavior?**
The tooltip will appear on hover for every data point present on the chart.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
