### PR TITLE
Added x-axis value to the context of a bubble chart tooltip.

### DIFF
--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -119,6 +119,7 @@ export class BubbleSeriesComponent implements OnChanges {
           series: seriesName,
           name: d.name,
           value: d.y,
+          x: d.x,
           radius: d.r
         };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Default tooltip has access to x and y value of a circle in the bubble chart. However, the context of a custom template has not.


**What is the new behavior?**
The context of a custom tooltip template contains also x value.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
