### PR TITLE
(fix): Rename ngOutletContext (deprecated) to ngTemplateOutletContext

### DIFF
--- a/src/common/tooltip/tooltip.component.ts
+++ b/src/common/tooltip/tooltip.component.ts
@@ -22,7 +22,7 @@ import { AlignmentTypes } from './alignment.type';
         <span *ngIf="!title">
           <ng-template
             [ngTemplateOutlet]="template"
-            [ngOutletContext]="{ model: context }">
+            [ngTemplateOutletContext]="{ model: context }">
           </ng-template>
         </span>
         <span

--- a/src/force-directed-graph/force-directed-graph.component.ts
+++ b/src/force-directed-graph/force-directed-graph.component.ts
@@ -40,7 +40,7 @@ import { ColorHelper } from '../common/color.helper';
           <svg:g *ngFor="let link of links; trackBy:trackLinkBy">
             <ng-template *ngIf="linkTemplate"
               [ngTemplateOutlet]="linkTemplate"
-              [ngOutletContext]="{ $implicit: link }">
+              [ngTemplateOutletContext]="{ $implicit: link }">
             </ng-template>
             <svg:line *ngIf="!linkTemplate"
               strokeWidth="1" class="edge"
@@ -67,7 +67,7 @@ import { ColorHelper } from '../common/color.helper';
             [tooltipContext]="node">
             <ng-template *ngIf="nodeTemplate"
               [ngTemplateOutlet]="nodeTemplate"
-              [ngOutletContext]="{ $implicit: node }">
+              [ngTemplateOutletContext]="{ $implicit: node }">
             </ng-template>
             <svg:circle *ngIf="!nodeTemplate" r="5" />
           </svg:g>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`ngOutletContext` is being used. It is deprecated since angular v4 and will be removed in angular v5.

**What is the new behavior?**

`ngOutletContext` is renamed to `ngTemplateOutletContext`.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No