### PR TITLE
Fix(pie): Update pie chart gradients on color changes

### DIFF
--- a/src/common/svg-radial-gradient.component.ts
+++ b/src/common/svg-radial-gradient.component.ts
@@ -22,27 +22,43 @@ import {
 })
 export class SvgRadialGradientComponent implements OnChanges {
 
-  @Input() color;
-  @Input() name;
-  @Input() startOpacity;
+  @Input() color: string;
+  @Input() name: string;
+  @Input() startOpacity: number;
   @Input() endOpacity = 1;
   @Input() cx: number = 0;
   @Input() cy: number = 0;
-  @Input() stops: any[];
+
+  @Input()
+  get stops(): any[] {
+    return this.stopsInput || this.stopsDefault;
+  }
+
+  set stops(value: any[]) {
+    this.stopsInput = value;
+  }
 
   r: string;
 
+  private stopsInput: any[];
+  private stopsDefault: any[];
+
   ngOnChanges(changes: SimpleChanges): void {
     this.r = '30%';
-    this.stops = this.stops || [{
-      offset: 0,
-      color: this.color,
-      opacity: this.startOpacity
-    }, {
-      offset: 100,
-      color: this.color,
-      opacity: this.endOpacity
-    }];
+    if (
+      ('color' in changes) ||
+      ('startOpacity' in changes) ||
+      ('endOpacity' in changes)) {
+        this.stopsDefault = [{
+          offset: 0,
+          color: this.color,
+          opacity: this.startOpacity
+        }, {
+          offset: 100,
+          color: this.color,
+          opacity: this.endOpacity
+        }];
+    }
   }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If the color input to a pie chart changes and the chart uses gradients, the colors are not updated.


**What is the new behavior?**
Colors are now updated.


**Does this PR introduce a breaking change?** (check one with "x")
No
