### PR TITLE
Fix labels in number cards (IE & Firefox)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copy:styles": "cpx \"build/**/*.css\" release",
     "watch": "webpack --display-error-details --watch",
     "start": "webpack-dev-server",
-    "start:host": "webpack-dev-server --host 0.0.0.0",
+    "start:host": "webpack-dev-server --host 0.0.0.0 --disable-host-check",
     "start:hmr": "webpack-dev-server --env.HMR",
     "release": "npm-run-all build:release",
     "package": "npm-run-all -s clean copy:build build:sass package:replace-scss package:aot build:package package:minify copy:styles clean:build",

--- a/src/number-card/card.component.scss
+++ b/src/number-card/card.component.scss
@@ -19,6 +19,7 @@ ngx-charts-number-card {
 
     .value-text {
       pointer-events: none;
+      dominant-baseline: hanging;
     }
   }
 

--- a/src/number-card/card.component.scss
+++ b/src/number-card/card.component.scss
@@ -17,7 +17,8 @@ ngx-charts-number-card {
       }
     }
 
-    .value-text {
+    .value-text,
+    .trimmed-label {
       pointer-events: none;
       dominant-baseline: hanging;
     }

--- a/src/number-card/card.component.ts
+++ b/src/number-card/card.component.ts
@@ -31,21 +31,19 @@ import { count, decimalChecker } from '../common/count';
         [attr.d]="bandPath"
       />
       <title>{{label}}</title>
-      <svg:foreignObject
+      <svg:text
         class="trimmed-label"
         x="5"
         [attr.x]="textPadding[3]"
         [attr.y]="cardHeight - textPadding[2]"
         [attr.width]="textWidth"
         [attr.height]="labelFontSize + textPadding[2]"
-        alignment-baseline="hanging">
-        <xhtml:p
-          [style.color]="textColor"
-          [style.fontSize.px]="labelFontSize"
-          [style.lineHeight.px]="labelFontSize"
-          [innerHTML]="formattedLabel">
-        </xhtml:p>
-      </svg:foreignObject>
+        alignment-baseline="hanging"
+        [style.color]="textColor"
+        [style.fontSize.px]="labelFontSize"
+        [style.lineHeight.px]="labelFontSize">
+        {{formattedLabel}}
+      </svg:text>
       <svg:text #textEl
         class="value-text"
         [attr.x]="textPadding[3]"

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -3,3 +3,9 @@
 if (typeof SVGElement.prototype.contains === 'undefined') {
   SVGElement.prototype.contains = HTMLDivElement.prototype.contains;
 }
+
+// IE11 fix (http://caniuse.com/#search=classList)
+if (!('classList' in document.createElementNS('http://www.w3.org/2000/svg', 'g'))) {
+  const descr = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'classList');
+  Object.defineProperty(SVGElement.prototype, 'classList', descr);
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In number cards labels won't be displayed in IE11 and are misaligned in firefox (https://github.com/swimlane/ngx-charts/issues/541)


**What is the new behavior?**
- Alignement fixed
- Label will be displayed
- Adds new polyfill for svg classList in IE
- In start:host script, disable-host-check flag added to allow network wide access to dev server


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
