### PR TITLE
Bugfix exception when launching Universal Server

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,5 +1,5 @@
 // IE11 fix
 // Ref: https://github.com/swimlane/ngx-charts/issues/386
-if (typeof SVGElement.prototype.contains === 'undefined') {
+if (typeof(SVGElement) !== 'undefined' && typeof SVGElement.prototype.contains === 'undefined') {
   SVGElement.prototype.contains = HTMLDivElement.prototype.contains;
 }


### PR DESCRIPTION
Fixes an exception that happens when launching Universal Server.

```
npm info lifecycle p4-monitor-angular@0.0.0~postbuild:universal:server: p4-monitor-angular@0.0.0
npm info ok
npm info lifecycle p4-monitor-angular@0.0.0~postbuild:universal:prod: p4-monitor-angular@0.0.0
npm info ok
/workdir/p4-monitor-angular/dist/server/server.js:157204
if (typeof SVGElement.prototype.contains === 'undefined') {
           ^

ReferenceError: SVGElement is not defined
    at Object.defineProperty.value (/workdir/p4-monitor-angular/dist/server/server.js:157204:12)
    at __webpack_require__ (/workdir/p4-monitor-angular/dist/server/server.js:20:30)
    at Object.SVGElement.contains (/workdir/p4-monitor-angular/dist/server/server.js:157141:69)
    at __webpack_require__ (/workdir/p4-monitor-angular/dist/server/server.js:20:30)
    at Object.defineProperty.value (/workdir/p4-monitor-angular/dist/server/server.js:125824:11)
    at __webpack_require__ (/workdir/p4-monitor-angular/dist/server/server.js:20:30)
    at Object.hasOwn (/workdir/p4-monitor-angular/dist/server/server.js:79980:37)
    at __webpack_require__ (/workdir/p4-monitor-angular/dist/server/server.js:20:30)
    at Object.defineProperty.value (/workdir/p4-monitor-angular/dist/server/server.js:63:18)
    at Object.<anonymous> (/workdir/p4-monitor-angular/dist/server/server.js:66:10)
```