### PR TITLE
Pass extra field to bubble chart select event

### DIFF
--- a/src/bubble-chart/bubble-series.component.ts
+++ b/src/bubble-chart/bubble-series.component.ts
@@ -33,7 +33,7 @@ import { formatLabel } from '../common/label.helper';
           [pointerEvents]="'all'"
           [data]="circle.value"
           [classNames]="circle.classNames"
-          (select)="onClick($event, circle.label)"
+          (select)="onClick($event, circle.label, circle.data)"
           (activate)="activateCircle(circle)"
           (deactivate)="deactivateCircle(circle)"
           ngx-tooltip
@@ -118,7 +118,8 @@ export class BubbleSeriesComponent implements OnChanges {
           name: d.name,
           value: d.y,
           x: d.x,
-          radius: d.r
+          radius: d.r,
+          extra: d.extra
         };
 
         return {
@@ -172,10 +173,11 @@ export class BubbleSeriesComponent implements OnChanges {
     `;
   }
 
-  onClick(value, label): void {
+  onClick(value, label, data): void {
     this.select.emit({
       name: label,
-      value
+      value,
+      extra: data.extra
     });
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The `extra` field is not passed on select events in bubble charts.
(Assuming that the `extra` field is used for passing additional data on click events, as mentioned in https://github.com/swimlane/ngx-charts/pull/303)

**What is the new behavior?**
The `extra` field can be retrieved on select events (addresses https://github.com/swimlane/ngx-charts/issues/506 for bubble charts).

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
