### PR TITLE
Change onDeactivate in the gauge component to emit the correct value …

### DIFF
--- a/src/gauge/gauge.component.ts
+++ b/src/gauge/gauge.component.ts
@@ -326,7 +326,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
     this.activeEntries.splice(idx, 1);
     this.activeEntries = [...this.activeEntries];
 
-    this.deactivate.emit({ value: event, entries: this.activeEntries });
+    this.deactivate.emit({ value: item, entries: this.activeEntries });
   }
 
   isActive(entry): boolean {


### PR DESCRIPTION
…instead of the event value from the global scope

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, when hovering over a gauge arc, a ReferenceError is thrown when a deactivate event is emitted because the wrong variable was used.

**What is the new behavior?**
The component no longer throws the error.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
