### PR TITLE
(fix): Export polyfills to fix AoT build issue with Angular 5

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,5 +1,10 @@
-// IE11 fix
-// Ref: https://github.com/swimlane/ngx-charts/issues/386
-if (typeof(SVGElement) !== 'undefined' && typeof SVGElement.prototype.contains === 'undefined') {
-  SVGElement.prototype.contains = HTMLDivElement.prototype.contains;
+// The export is needed here to generate a valid polyfills.metadata.json file
+export function ngxChartsPolyfills() {
+  // IE11 fix
+  // Ref: https://github.com/swimlane/ngx-charts/issues/386
+  if (typeof(SVGElement) !== 'undefined' && typeof SVGElement.prototype.contains === 'undefined') {
+    SVGElement.prototype.contains = HTMLDivElement.prototype.contains;
+  }
 }
+
+ngxChartsPolyfills();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

AoT build fails with:

```
ERROR in TypeError: Cannot read property 'version' of null
    at readMetadataFile (/Users/ez/Github/highland-ui/node_modules/@angular/compiler-cli/src/transformers/metadata_reader.js:66:29)...
```

**What is the new behavior?**

AoT build succeeds.

Closes #639

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No