### PR TITLE
Fix for showing tooltips in the right place

### DIFF
--- a/src/common/tooltip-area.component.ts
+++ b/src/common/tooltip-area.component.ts
@@ -145,7 +145,7 @@ export class TooltipArea {
   }
 
   mouseMove(event) {
-    const xPos = event.offsetX - this.dims.xOffset;
+    const xPos = (event.pageX - event.target.getBoundingClientRect().left) - this.dims.xOffset;
 
     const closestIndex = this.findClosestPointIndex(xPos);
     const closestPoint = this.xSet[closestIndex];


### PR DESCRIPTION
This pull request fixes #469 where data points aren't reachable through the mouse over event. Since event.offsetX isn't fully supported in all browsers (i.e. it gives different values on IE, Firefox then in Chrome for example), replacing event.offsetX by event.pageX - event.target.getBoundingClientRect().left gives a better cross browser solution.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
