### PR TITLE
Fix for wrongly positioned tooltip

### DIFF
--- a/src/common/tooltip-area.component.ts
+++ b/src/common/tooltip-area.component.ts
@@ -145,7 +145,7 @@ export class TooltipArea {
   }
 
   mouseMove(event) {
-    const xPos = event.offsetX - this.dims.xOffset;
+    const xPos = event.pageX - event.target.getBoundingClientRect().left;
 
     const closestIndex = this.findClosestPointIndex(xPos);
     const closestPoint = this.xSet[closestIndex];


### PR DESCRIPTION
Solves #469. 

event.pageX - event.target.getBoundingClientRect().left gives me a different value then event.offsetX as where as in Firefox and IE these two result in exactly the same numbers. The difference between the numbers in Chrome is compensated by subtracting this.dims.xOffset. 

To make this work in all browsers we could just use
const xPos = event.pageX - event.target.getBoundingClientRect().left; instead of using offsetX and subtracting it with dims.xOffset.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
See #469 


**What is the new behavior?**
posX is now cross browser always the same.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
