### PR TITLE
Handle area charts based on a specific floor value

### DIFF
--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -63,6 +63,7 @@ import { id } from '../utils/id';
             <svg:g ngx-charts-area-series
               [xScale]="xScale"
               [yScale]="yScale"
+              [baseValue]="baseValue"
               [colors]="colors"
               [data]="series"
               [activeEntries]="activeEntries"
@@ -120,6 +121,7 @@ import { id } from '../utils/id';
           <svg:g ngx-charts-area-series
             [xScale]="timelineXScale"
             [yScale]="timelineYScale"
+            [baseValue]="baseValue"
             [colors]="colors"
             [data]="series"
             [scaleType]="scaleType"
@@ -142,6 +144,7 @@ export class AreaChartComponent extends BaseChartComponent {
   @Input() state;
   @Input() xAxis;
   @Input() yAxis;
+  @Input() baseValue: any = 'auto';
   @Input() autoScale;
   @Input() showXAxisLabel;
   @Input() showYAxisLabel;
@@ -314,6 +317,9 @@ export class AreaChartComponent extends BaseChartComponent {
     const values = [...domain];
     if (!this.autoScale) {
       values.push(0);
+    }
+    if (this.baseValue !== 'auto') {
+      values.push(this.baseValue);
     }
 
     const min = this.yScaleMin

--- a/src/area-chart/area-series.component.ts
+++ b/src/area-chart/area-series.component.ts
@@ -35,6 +35,7 @@ export class AreaSeriesComponent implements OnChanges {
   @Input() data;
   @Input() xScale;
   @Input() yScale;
+  @Input() baseValue: any = 'auto';
   @Input() colors;
   @Input() scaleType;
   @Input() stacked: boolean = false;
@@ -81,13 +82,13 @@ export class AreaSeriesComponent implements OnChanges {
     } else {
       currentArea = area<any>()
         .x(xProperty)
-        .y0(() => this.yScale.range()[0])
+        .y0(() => this.baseValue === 'auto' ? this.yScale.range()[0] : this.yScale(this.baseValue))
         .y1(d => this.yScale(d.value));
 
       startingArea = area<any>()
         .x(xProperty)
-        .y0(d => this.yScale.range()[0])
-        .y1(d => this.yScale.range()[0]);
+        .y0(d => this.baseValue === 'auto' ? this.yScale.range()[0] : this.yScale(this.baseValue))
+        .y1(d => this.baseValue === 'auto' ? this.yScale.range()[0] : this.yScale(this.baseValue));
     }
 
     currentArea.curve(this.curve);


### PR DESCRIPTION
The purpose of this option is to provide an area chart
which start from a specific floor value and can handle reverse areas.
Instead of starting the area from the lowest value of all series,
if a serie contains values inferior to the floor value,
it will display a reverse area with a "negative" spike.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

The current behaviour always start areas from the lowest values of all series.

**What is the new behavior?**

Areas can (optional) start from a specific floor value, which can display negative spikes and reverse areas.
I opened an issue [here](https://github.com/swimlane/ngx-charts/issues/681) before making this PR.

Example :

![Reverse area chart example](https://i.imgur.com/pmb8bKE.png)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

No breaking change, this is a new @Input with default value to 'auto'.

**Other information**:

Demo has not been updated. If my PR is discussed, I can add a checkbox on options panel.