### PR TITLE
Added Optional Stroke Color to all bar graphs.

### DIFF
--- a/src/bar-chart/bar-horizontal-2d.component.ts
+++ b/src/bar-chart/bar-horizontal-2d.component.ts
@@ -69,6 +69,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [activeEntries]="activeEntries"
             [yScale]="innerScale"
             [colors]="colors"
+            [strokeColor]="strokeColor"
             [series]="group.series"
             [dims]="dims"
             [gradient]="gradient"
@@ -122,6 +123,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
   @Input() xScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-horizontal-normalized.component.ts
+++ b/src/bar-chart/bar-horizontal-normalized.component.ts
@@ -63,6 +63,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [yScale]="yScale"
             [activeEntries]="activeEntries"
             [colors]="colors"
+            [strokeColor]="strokeColor"
             [series]="group.series"
             [dims]="dims"
             [gradient]="gradient"
@@ -112,6 +113,7 @@ export class BarHorizontalNormalizedComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-horizontal-stacked.component.ts
+++ b/src/bar-chart/bar-horizontal-stacked.component.ts
@@ -62,6 +62,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [xScale]="xScale"
             [yScale]="yScale"
             [colors]="colors"
+            [strokeColor]="strokeColor"
             [series]="group.series"
             [activeEntries]="activeEntries"
             [dims]="dims"
@@ -113,6 +114,7 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() xScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-horizontal.component.ts
+++ b/src/bar-chart/bar-horizontal.component.ts
@@ -50,6 +50,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [xScale]="xScale"
           [yScale]="yScale"
           [colors]="colors"
+          [strokeColor]="strokeColor"
           [series]="results"
           [dims]="dims"
           [gradient]="gradient"
@@ -90,6 +91,7 @@ export class BarHorizontalComponent extends BaseChartComponent {
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
   @Input() xScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical-2d.component.ts
+++ b/src/bar-chart/bar-vertical-2d.component.ts
@@ -67,6 +67,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [xScale]="innerScale"
           [yScale]="valueScale"
           [colors]="colors"
+          [strokeColor]="strokeColor"
           [series]="group.series"
           [dims]="dims"
           [gradient]="gradient"
@@ -120,6 +121,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
   @Input() yScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical-normalized.component.ts
+++ b/src/bar-chart/bar-vertical-normalized.component.ts
@@ -62,6 +62,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [yScale]="yScale"
             [activeEntries]="activeEntries"
             [colors]="colors"
+            [strokeColor]="strokeColor"
             [series]="group.series"
             [dims]="dims"
             [gradient]="gradient"
@@ -111,6 +112,7 @@ export class BarVerticalNormalizedComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -62,6 +62,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [yScale]="yScale"
             [activeEntries]="activeEntries"
             [colors]="colors"
+            [strokeColor]="strokeColor"
             [series]="group.series"
             [dims]="dims"
             [gradient]="gradient"
@@ -112,6 +113,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() yScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -50,6 +50,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [xScale]="xScale"
           [yScale]="yScale"
           [colors]="colors"
+          [strokeColor]="strokeColor"
           [series]="results"
           [dims]="dims"
           [gradient]="gradient"
@@ -90,6 +91,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
   @Input() yScaleMax: number;
+  @Input() strokeColor: string = 'none';
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -25,7 +25,7 @@ import { id } from '../utils/id';
     </svg:defs>
     <svg:path
       class="bar"
-      stroke="none"
+      [attr.stroke]="strokeColor"
       [class.active]="isActive"
       [attr.d]="path"
       [attr.fill]="hasGradient ? gradientFill : fill"
@@ -49,6 +49,7 @@ export class BarComponent implements OnChanges {
   @Input() isActive: boolean = false;
   @Input() stops: any[];
   @Input() animations: boolean = true;
+  @Input() strokeColor: string = 'none';
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();

--- a/src/bar-chart/series-horizontal.component.ts
+++ b/src/bar-chart/series-horizontal.component.ts
@@ -27,6 +27,7 @@ import { formatLabel } from '../common/label.helper';
       [x]="bar.x"
       [y]="bar.y"
       [fill]="bar.color"
+      [strokeColor]="strokeColor"
       [stops]="bar.gradientStops"
       [data]="bar.data"
       [orientation]="'horizontal'"
@@ -76,6 +77,7 @@ export class SeriesHorizontal implements OnChanges {
   @Input() tooltipTemplate: TemplateRef<any>;
   @Input() roundEdges: boolean;
   @Input() animations: boolean = true;
+  @Input() strokeColor: string = 'none';
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -27,6 +27,7 @@ import { formatLabel } from '../common/label.helper';
       [x]="bar.x"
       [y]="bar.y"
       [fill]="bar.color"
+      [strokeColor]="strokeColor"
       [stops]="bar.gradientStops"
       [data]="bar.data"
       [orientation]="'vertical'"
@@ -73,6 +74,7 @@ export class SeriesVerticalComponent implements OnChanges {
   @Input() tooltipTemplate: TemplateRef<any>;
   @Input() roundEdges: boolean;
   @Input() animations: boolean = true;
+  @Input() strokeColor: string = 'none';
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();


### PR DESCRIPTION
Added dynamic stroke color, set to none if none is passed.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, the stroke on each bar of the bar graphs is set to none.


**What is the new behavior?**
In any of the bar graph components, you may add [strokeColor]="<colorName or none>" property to outline each bar with the corresponding color.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
