### PR TITLE
(feat): Allow configuration of label trimming on pie chart

### DIFF
--- a/src/pie-chart/pie-label.component.ts
+++ b/src/pie-chart/pie-label.component.ts
@@ -23,7 +23,7 @@ import { trimLabel } from '../common/trim-label.helper';
         dy=".35em"
         [style.textAnchor]="textAnchor()"
         [style.shapeRendering]="'crispEdges'">
-        {{trimLabel(label, 10)}}
+        {{disableLabelTrim ? label : trimLabel(label, labelTrimSize)}}
       </svg:text>
     </svg:g>
     <svg:path
@@ -46,6 +46,8 @@ export class PieLabelComponent implements OnChanges {
   @Input() value;
   @Input() explodeSlices;
   @Input() animations: boolean = true;
+  @Input() disableLabelTrim: boolean = true;
+  @Input() labelTrimSize: number = 10;
 
   trimLabel: (label: string, max?: number) => string;
   line: string;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Label on pie charts trim at 10 characters and there's no way of changing this


**What is the new behavior?**
Labels on pie charts can now be configured to not trim, or a custom trim length. Omission of either results in 10 characters trimming as is current behavior.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
Much needed, label trimming is annoying when it's fixed and can't be changed!

As per the [comment here](https://github.com/swimlane/ngx-charts/issues/337#issuecomment-295380159)
> There is not one at the moment. The reason for that is that we have an algorithm which positions the labels in a way that they don't overlap, but it assumes they are all of the same height (single line).

> If we allow multi-line labels we would have to modify that algorithm, but there would be no guarantee that overlaps will be prevented, because there would be no limit on the length of the labels.

> Another issue here is that the labels also have a limited horizontal space, which is why we truncate them.

> I am open to suggestions on ways to handle these use cases.

Perhaps just letting users fiddle with it is good enough for now till a solution is found?

Closes #513 
Closes #337 