### PR TITLE
(feat): Added options for formatting the name, value and percentage values in the advanced legend component

### DIFF
--- a/docs/charts/advanced-pie-chart.md
+++ b/docs/charts/advanced-pie-chart.md
@@ -17,6 +17,9 @@
 | label           | string      | 'Total'       | the text to show under the total value                                                                          |
 | tooltipDisabled | boolean     | false         | show or hide the tooltip                                                                                        |
 | tooltipTemplate | TemplateRef |               | a custom ng-template to be displayed inside the tooltip                                                         |
+| valueFormatting | function    |               | function that formats the numerical value in the chart legend                                                   |
+| nameFormatting  | function    |               | function that formats name in the chart legend                                                                  |
+| percentageFormatting | function |             | function that formats the percentage number in the chart legend                                                 |
 
 # Outputs
 

--- a/src/common/legend/advanced-legend.component.spec.ts
+++ b/src/common/legend/advanced-legend.component.spec.ts
@@ -1,0 +1,134 @@
+import { async, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+
+import { ChartCommonModule } from '../chart-common.module';
+import { ColorHelper } from '../color.helper';
+
+@Component({
+  selector: 'test-component',
+  template: ''
+})
+class TestComponent {
+
+  legendLabel: string = 'Test legend label';
+  colors: any;
+  legendWidth: number;
+  data: any;
+
+  constructor() {
+    const scheme = {domain: ['#5AA454', '#A10A28', '#C7B42C', '#AAAAAA']};
+    this.colors = new ColorHelper(scheme, 'ordinal', [], null);
+    this.data = [
+      {name: 'a', value: 8},
+      {name: 'b', value: 12},
+      {name: 'c', value: 20},
+      {name: 'd', value: 30},
+      {name: 'e', value: 46},
+      {name: 'f', value: 24}
+    ];
+  }
+
+  valueFormatting: (value: number) => any = value => value;
+  labelFormatting: (value: string) => any = label => label;
+  percentageFormatting: (value: number) => any = percentage => percentage;
+}
+
+describe('<ngx-charts-advanced-legend>', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [ChartCommonModule]
+    });
+
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+                <ngx-charts-advanced-legend
+                  [label]="legendLabel"
+                  [colors]="colors"
+                  [data]="data"
+                  [width]="legendWidth"
+                  [animations]="false"
+                  [valueFormatting]="valueFormatting"
+                  [labelFormatting]="labelFormatting"
+                  [percentageFormatting]="percentageFormatting">
+                </ngx-charts-advanced-legend>
+            `
+      }
+    });
+  });
+
+  it('should render label and legend with values for each item', async(() => {
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const labelElement = fixture.debugElement.nativeElement.querySelector('.total-label');
+      const roundedTotalElement = fixture.debugElement.nativeElement.querySelector('.advanced-pie-legend').children[0];
+      const {
+        legendItemsElements,
+        legendItemValueElements,
+        legendItemLabelElements,
+        legendItemPercentElements
+      } = loadLegendItemElements(fixture);
+
+      expect(labelElement).toBeDefined();
+      expect(roundedTotalElement).toBeDefined();
+
+      expect(labelElement.textContent).toContain('Test legend label');
+      expect(roundedTotalElement.textContent).toContain('140');
+      expect(legendItemsElements.childElementCount).toBe(6);
+      expect(Array.from(legendItemValueElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['8', '12', '20', '30', '46', '24']);
+      expect(Array.from(legendItemLabelElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+      expect(Array.from(legendItemPercentElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['5.714%', '8.571%', '14.286%', '21.429%', '32.857%', '17.143%']);
+    });
+  }));
+
+  it('should apply formatting functions', async(() => {
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      const component = fixture.componentInstance;
+      component.valueFormatting = value => value.toFixed(2);
+      component.labelFormatting = label => `X:${label}`;
+      component.percentageFormatting = percentage => Math.round(percentage);
+      fixture.detectChanges();
+
+      const {
+        legendItemsElements,
+        legendItemValueElements,
+        legendItemLabelElements,
+        legendItemPercentElements
+      } = loadLegendItemElements(fixture);
+
+      expect(legendItemsElements.childElementCount).toBe(6);
+      expect(Array.from(legendItemValueElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['8.00', '12.00', '20.00', '30.00', '46.00', '24.00']);
+      expect(Array.from(legendItemLabelElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['X:a', 'X:b', 'X:c', 'X:d', 'X:e', 'X:f']);
+      expect(Array.from(legendItemPercentElements).map((x: Element) => x.textContent.trim()))
+        .toEqual(['6%', '9%', '14%', '21%', '33%', '17%']);
+    });
+  }));
+
+  function loadLegendItemElements(fixture) {
+    const legendItemsElements = fixture.debugElement.nativeElement
+      .querySelector('.legend-items');
+    const legendItemValueElements = fixture.debugElement.nativeElement
+      .querySelectorAll('.legend-items .item-value');
+    const legendItemLabelElements = fixture.debugElement.nativeElement
+      .querySelectorAll('.legend-items .item-label');
+    const legendItemPercentElements = fixture.debugElement.nativeElement
+      .querySelectorAll('.legend-items .item-percent');
+    return {
+      legendItemsElements,
+      legendItemValueElements,
+      legendItemLabelElements,
+      legendItemPercentElements
+    };
+  }
+
+});

--- a/src/common/legend/advanced-legend.component.ts
+++ b/src/common/legend/advanced-legend.component.ts
@@ -1,12 +1,12 @@
 import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
   ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
   SimpleChanges,
-  ViewEncapsulation,
-  OnChanges
+  ViewEncapsulation
 } from '@angular/core';
 import { trimLabel } from '../trim-label.helper';
 import { formatLabel } from '../label.helper';
@@ -85,6 +85,10 @@ export class AdvancedLegendComponent implements OnChanges  {
   total: number;
   roundedTotal: number;
 
+  @Input() valueFormatting: (value: number) => any = value => value;
+  @Input() labelFormatting: (value: string) => any = label => label;
+  @Input() percentageFormatting: (value: number) => any = percentage => percentage;
+
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
   }
@@ -106,15 +110,15 @@ export class AdvancedLegendComponent implements OnChanges  {
     return this.data.map((d, index) => {
       const label = formatLabel(d.name);
       const value = d.value;
-      const percentage = (this.total > 0) ? value / this.total * 100 : 0;
       const color = this.colors.getColor(label);
+      const percentage = (this.total > 0) ? value / this.total * 100 : 0;
 
       return {
-        value,
+        value: this.valueFormatting(value),
         color,
-        label: trimLabel(label, 20),
+        label: trimLabel(this.labelFormatting(label), 20),
         originalLabel: d.name,
-        percentage
+        percentage: this.percentageFormatting(percentage)
       };
     });
   }

--- a/src/pie-chart/advanced-pie-chart.component.ts
+++ b/src/pie-chart/advanced-pie-chart.component.ts
@@ -1,12 +1,12 @@
 import {
+  ChangeDetectionStrategy,
   Component,
+  ContentChild,
+  EventEmitter,
   Input,
   Output,
-  EventEmitter,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  ContentChild,
-  TemplateRef
+  TemplateRef,
+  ViewEncapsulation
 } from '@angular/core';
 
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
@@ -55,6 +55,9 @@ import { BaseChartComponent } from '../common/base-chart.component';
           [width]="width - dims.width - margin[1]"
           [label]="label"
           [animations]="animations"
+          [valueFormatting]="valueFormatting"
+          [labelFormatting]="nameFormatting"
+          [percentageFormatting]="percentageFormatting"
           (select)="onClick($event)"
           (activate)="onActivate($event)"
           (deactivate)="onDeactivate($event)">
@@ -91,6 +94,10 @@ export class AdvancedPieChartComponent extends BaseChartComponent {
   colors: ColorHelper;
   legendWidth: number;
   margin = [20, 20, 20, 20];
+
+  @Input() valueFormatting: (value: number) => any = value => value;
+  @Input() nameFormatting: (value: string) => any = label => label;
+  @Input() percentageFormatting: (value: number) => any = percentage => percentage;
 
   update(): void {
     super.update();


### PR DESCRIPTION
Added to be used in the advanced pie chart component.
Should help with #201

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, the formatting for values in the legend cannot be formatted by a client of the api. This helped bring up the issue seen in #201 

**What is the new behavior?**

It is possible to provide a formatter function for the name, value, and percentage properties of the legend.

The existing behavior remains unchanged.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
