### PR TITLE
Fix for path error when animating bar charts

### DIFF
--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -54,6 +54,8 @@ export class BarComponent implements OnChanges {
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();
 
+  _edges: boolean[];
+
   element: any;
   path: any;
   gradientId: any;
@@ -189,23 +191,25 @@ export class BarComponent implements OnChanges {
   }
 
   get edges() {
-    let edges = [false, false, false, false];
+    if (this._edges === undefined) {
+      this._edges = [false, false, false, false];
+    }
     if (this.roundEdges) {
       if (this.orientation === 'vertical') {
         if (this.data.value > 0) {
-          edges =  [true, true, false, false];
-        } else {
-          edges =  [false, false, true, true];
+          this._edges =  [true, true, false, false];
+        } else if (this.data.value < 0) {
+          this._edges =  [false, false, true, true];
         }
       } else if (this.orientation === 'horizontal') {
         if (this.data.value > 0) {
-          edges =  [false, true, false, true];
-        } else {
-          edges =  [true, false, true, false];
+          this._edges =  [false, true, false, true];
+        } else if (this.data.value < 0) {
+          this._edges =  [true, false, true, false];
         }
       }
     }
-    return edges;
+    return this._edges;
   }
 
   @HostListener('mouseenter')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When changing data of bars to 0 the animation is broken because it changes the edges that needs rounding.
**What is the new behavior?**
If the data is 0 the edges are maintained instead of changed.



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

Probably related to #498 but haven't been able to check that yet.
