### PR TITLE
Avoid invalid paths when rect shape has 0 width or height

### DIFF
--- a/src/common/shape.helper.ts
+++ b/src/common/shape.helper.ts
@@ -8,6 +8,12 @@
 export function roundedRect(x, y, w, h, r, [tl, tr, bl, br]: boolean[]) {
   let retval = '';
 
+  w = w | 0;
+  h = h | 0;
+
+  w = w < 1 ? 1 : w;
+  h = h < 1 ? 1 : h;
+
   retval = `M${[x + r, y]}`;
   retval += `h${w - 2 * r}`;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If a bar chart has many values the height (or width) of the bar can become <1px, resulting in an invalid path.


**What is the new behavior?**
Bars have a minimum height and width of 1px.


**Does this PR introduce a breaking change?** (check one with "x")
No
