### PR TITLE
Make margins optional for pie chart component

### DIFF
--- a/src/pie-chart/pie-chart.component.ts
+++ b/src/pie-chart/pie-chart.component.ts
@@ -71,8 +71,9 @@ export class PieChartComponent extends BaseChartComponent {
   @Input() trimLabels: boolean = true;
   @Input() maxLabelLength: number = 10;
   @Input() tooltipText: any;
-
   @Output() dblclick = new EventEmitter();
+  // optional margins
+  @Input() margins: number[];
   @Output() select = new EventEmitter();
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -86,25 +87,27 @@ export class PieChartComponent extends BaseChartComponent {
   colors: ColorHelper;
   domain: any;
   dims: any;
-  margin = [20, 20, 20, 20];
   legendOptions: any;
 
   update(): void {
     super.update();
 
-    if (this.labels) {
-      this.margin = [30, 80, 30, 80];
+    if (this.labels && this.hasNoOptionalMarginsSet()) {
+      this.margins = [30, 80, 30, 80];
+    } else if (!this.labels && this.hasNoOptionalMarginsSet()) {
+      // default value for margins
+      this.margins = [20, 20, 20, 20];
     }
 
     this.dims = calculateViewDimensions({
       width: this.width,
       height: this.height,
-      margins: this.margin,
+      margins: this.margins,
       showLegend: this.legend,
     });
 
-    const xOffset = this.margin[3] + this.dims.width / 2;
-    const yOffset = this.margin[0] + this.dims.height / 2;
+    const xOffset = this.margins[3] + this.dims.width / 2;
+    const yOffset = this.margins[0] + this.dims.height / 2;
     this.translation = `translate(${xOffset}, ${yOffset})`;
     this.outerRadius = Math.min(this.dims.width, this.dims.height);
     if (this.labels) {
@@ -188,4 +191,7 @@ export class PieChartComponent extends BaseChartComponent {
     this.deactivate.emit({ value: item, entries: this.activeEntries });
   }
 
+  private hasNoOptionalMarginsSet(): boolean {
+    return !this.margins || this.margins.length <= 0;
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
Margins in the pie chart component have a hard coded value. When no label/legend for the chart is set, these margins take up unnecessary space. In our case we can't even make the component fit into the lower part of the specific page where we want to use the chart.

**What is the new behavior?**
The pie chart component now has an `@Input` field for margins. If desired, this field can be set. If it is not set or empty, there are two possibilities:

+ `labels` is set (and `margins` either unset or empty) -> `margins` will be set to `[30, 80, 30, 80]`, as it was previously the case.

+ `labels` is not set (and `margins` either unset or empty) -> `margins` will be set to `[20, 20, 20, 20]`, as it was previously the case.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information:**
The new behavior is similar to the one of e.g. `gauge.component.ts`, where the margins can be set optionally via an `@Input` field.