### PR TITLE
Performance improvement, (various charts, large data)

### DIFF
--- a/demo/sparkline/sparkline.component.ts
+++ b/demo/sparkline/sparkline.component.ts
@@ -89,15 +89,7 @@ export class SparklineComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = [];
-
-    for (const results of this.results) {
-      for (const d of results.series) {
-        if (!values.includes(d.name)) {
-          values.push(d.name);
-        }
-      }
-    }
+    let values = super.getUniqueXDomainValues();
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/demo/sparkline/sparkline.component.ts
+++ b/demo/sparkline/sparkline.component.ts
@@ -8,6 +8,7 @@ import { scaleLinear, scaleTime, scalePoint } from 'd3-scale';
 import { curveLinear } from 'd3-shape';
 
 import { calculateViewDimensions, ViewDimensions, BaseChartComponent, ColorHelper } from '../../src';
+import { getUniqueXDomainValues } from '../../src/common/domain.helper';
 
 @Component({
   selector: 'ngx-charts-sparkline',
@@ -89,7 +90,7 @@ export class SparklineComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = super.getUniqueXDomainValues();
+    let values = getUniqueXDomainValues(this.results);
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -303,15 +303,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = [];
-
-    for (const results of this.results) {
-      for (const d of results.series) {
-        if (!values.includes(d.name)) {
-          values.push(d.name);
-        }
-      }
-    }
+    let values = super.getUniqueXDomainValues();
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -16,6 +16,7 @@ import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensio
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { id } from '../utils/id';
+import { getUniqueXDomainValues } from '../common/domain.helper';
 
 @Component({
   selector: 'ngx-charts-area-chart-normalized',
@@ -303,7 +304,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = super.getUniqueXDomainValues();
+    let values = getUniqueXDomainValues(this.results);
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -16,6 +16,7 @@ import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensio
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { id } from '../utils/id';
+import { getUniqueXDomainValues } from '../common/domain.helper';
 
 @Component({
   selector: 'ngx-charts-area-chart-stacked',
@@ -281,7 +282,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = super.getUniqueXDomainValues();
+    let values = getUniqueXDomainValues(this.results);
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -281,15 +281,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = [];
-
-    for (const results of this.results) {
-      for (const d of results.series) {
-        if (!values.includes(d.name)) {
-          values.push(d.name);
-        }
-      }
-    }
+    let values = super.getUniqueXDomainValues();
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -16,6 +16,7 @@ import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensio
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { id } from '../utils/id';
+import { getUniqueXDomainValues } from '../common/domain.helper';
 
 @Component({
   selector: 'ngx-charts-area-chart',
@@ -250,7 +251,7 @@ export class AreaChartComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = super.getUniqueXDomainValues();
+    let values = getUniqueXDomainValues(this.results);
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -250,15 +250,7 @@ export class AreaChartComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = [];
-
-    for (const results of this.results) {
-      for (const d of results.series) {
-        if (!values.includes(d.name)) {
-          values.push(d.name);
-        }
-      }
-    }
+    let values = super.getUniqueXDomainValues();
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -135,6 +135,16 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
     }
   }
 
+  protected getUniqueXDomainValues(): any[] {
+    const valueSet = new Set();
+    for (const results of this.results) {
+      for (const d of results.series) {
+        valueSet.add(d.name);
+      }
+    }
+    return Array.from(valueSet);
+  }
+
   private bindWindowResizeEvent(): void {
     const source = observableFromEvent(window, 'resize', null, null);
     const subscription = source.pipe(debounceTime(200)).subscribe(e => {

--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -135,16 +135,6 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
     }
   }
 
-  protected getUniqueXDomainValues(): any[] {
-    const valueSet = new Set();
-    for (const results of this.results) {
-      for (const d of results.series) {
-        valueSet.add(d.name);
-      }
-    }
-    return Array.from(valueSet);
-  }
-
   private bindWindowResizeEvent(): void {
     const source = observableFromEvent(window, 'resize', null, null);
     const subscription = source.pipe(debounceTime(200)).subscribe(e => {

--- a/src/common/domain.helper.ts
+++ b/src/common/domain.helper.ts
@@ -1,0 +1,16 @@
+/**
+ * Based on the data, return an array with unique values.
+ *
+ * @export
+ * @returns array
+ * @param results
+ */
+export function getUniqueXDomainValues(results: any[]): any[] {
+  const valueSet = new Set();
+  for (const result of results) {
+    for (const d of result.series) {
+      valueSet.add(d.name);
+    }
+  }
+  return Array.from(valueSet);
+}

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -22,6 +22,7 @@ import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensio
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { id } from '../utils/id';
+import { getUniqueXDomainValues } from '../common/domain.helper';
 
 @Component({
   selector: 'ngx-charts-line-chart',
@@ -276,7 +277,7 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = super.getUniqueXDomainValues();
+    let values = getUniqueXDomainValues(this.results);
 
     this.scaleType = this.getScaleType(values);
     let domain = [];

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -276,15 +276,7 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = [];
-
-    for (const results of this.results) {
-      for (const d of results.series) {
-        if (!values.includes(d.name)) {
-          values.push(d.name);
-        }
-      }
-    }
+    let values = super.getUniqueXDomainValues();
 
     this.scaleType = this.getScaleType(values);
     let domain = [];


### PR DESCRIPTION
Another one coming in. :)

Converted to using sets instead of includes on possible large data.
Tackles #714 and maybe #519, but not completely.

For the usecase (2 lines, 30k datapoints) duration went from 600ms to 80ms, the function gets called 4 times, so it makes a difference, but it still takes a bit of time to load this graph.

With 100 points, the performance is about equal, below 100 datapoints, old scenario is faster.
But we are talking about overhead of going from set --> array, which in category of a 0.00x ms differences on my machine.

It just makes ngx-charts a bit more scalable/useable with larger data (>100 datapoints).

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Using Array.includes() to check for unique values.
For the usecase (2 lines, 30k datapoints): 600ms

**What is the new behavior?**
Using a Set to make sure everything is unique, and then converting to an array.
For the usecase (2 lines, 30k datapoints): 80ms

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
