### PR TITLE
Exposed tick width from the x and y ticks components

### DIFF
--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -46,6 +46,8 @@ import { id } from '../utils/id';
           [showLabel]="showXAxisLabel"
           [labelText]="xAxisLabel"
           [tickFormatting]="xAxisTickFormatting"
+          [maxTickWidth]="maxTickWidth"
+          [maxScaleTickWidth]="maxScaleTickWidth"
           (dimensionsChanged)="updateXAxisHeight($event)">
         </svg:g>
         <svg:g ngx-charts-y-axis
@@ -56,6 +58,8 @@ import { id } from '../utils/id';
           [showLabel]="showYAxisLabel"
           [labelText]="yAxisLabel"
           [tickFormatting]="yAxisTickFormatting"
+          [maxTickHeight]="maxTickHeight"
+          [maxScaleTickHeight]="maxScaleTickHeight"
           (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
         <svg:g [attr.clip-path]="clipPath">
@@ -161,6 +165,10 @@ export class AreaChartComponent extends BaseChartComponent {
   @Input() xScaleMax: any;
   @Input() yScaleMin: number;
   @Input() yScaleMax: number;
+  @Input() maxTickWidth: number;
+  @Input() maxScaleTickWidth: number;
+  @Input() maxTickHeight: number;
+  @Input() maxScaleTickHeight: number;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -233,7 +241,7 @@ export class AreaChartComponent extends BaseChartComponent {
     this.setColors();
     this.legendOptions = this.getLegendOptions();
 
-    this.transform = `translate(${ this.dims.xOffset }, ${ this.margin[0] })`;
+    this.transform = `translate(${this.dims.xOffset}, ${this.margin[0]})`;
 
     this.clipPathId = 'clip' + id().toString();
     this.clipPath = `url(#${this.clipPathId})`;
@@ -245,7 +253,7 @@ export class AreaChartComponent extends BaseChartComponent {
       this.timelineXDomain = this.getXDomain();
       this.timelineXScale = this.getXScale(this.timelineXDomain, this.timelineWidth);
       this.timelineYScale = this.getYScale(this.yDomain, this.timelineHeight);
-      this.timelineTransform = `translate(${ this.dims.xOffset }, ${ -this.margin[2] })`;
+      this.timelineTransform = `translate(${this.dims.xOffset}, ${-this.margin[2]})`;
     }
   }
 
@@ -344,7 +352,7 @@ export class AreaChartComponent extends BaseChartComponent {
     }
 
     scale.range([0, width])
-        .domain(domain);
+      .domain(domain);
 
     return this.roundDomains ? scale.nice() : scale;
   }
@@ -463,7 +471,7 @@ export class AreaChartComponent extends BaseChartComponent {
       return;
     }
 
-    this.activeEntries = [ item, ...this.activeEntries ];
+    this.activeEntries = [item, ...this.activeEntries];
     this.activate.emit({ value: item, entries: this.activeEntries });
   }
 

--- a/src/common/axes/x-axis-ticks.component.ts
+++ b/src/common/axes/x-axis-ticks.component.ts
@@ -53,7 +53,8 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() showGridLines = false;
   @Input() gridLineHeight;
   @Input() width;
-
+  @Input() maxTickWidth = 20;
+  @Input() maxScaleTickWidth = 100;
   @Output() dimensionsChanged = new EventEmitter();
 
   verticalSpacing: number = 20;
@@ -147,7 +148,7 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
     const maxBaseWidth = Math.floor(this.width / ticks.length);
 
     // calculate optimal angle
-    while(baseWidth > maxBaseWidth && angle > -90) {
+    while (baseWidth > maxBaseWidth && angle > -90) {
       angle -= 30;
       baseWidth = Math.cos(angle * (Math.PI / 180)) * wordWidth;
     }
@@ -157,8 +158,8 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
 
   getTicks() {
     let ticks;
-    const maxTicks = this.getMaxTicks(20);
-    const maxScaleTicks = this.getMaxTicks(100);
+    const maxTicks = this.getMaxTicks(this.maxTickWidth);
+    const maxScaleTicks = this.getMaxTicks(this.maxScaleTickWidth);
 
     if (this.tickValues) {
       ticks = this.tickValues;

--- a/src/common/axes/x-axis.component.ts
+++ b/src/common/axes/x-axis.component.ts
@@ -27,6 +27,8 @@ import { XAxisTicksComponent } from './x-axis-ticks.component';
         [showGridLines]="showGridLines"
         [gridLineHeight]="dims.height"
         [width]="dims.width"
+        [maxTickWidth]="maxTickWidth"
+        [maxScaleTickWidth]="maxScaleTickWidth"
         (dimensionsChanged)="emitTicksHeight($event)"
       />
       <svg:g ngx-charts-axis-label
@@ -52,6 +54,8 @@ export class XAxisComponent implements OnChanges {
   @Input() xAxisTickInterval;
   @Input() xAxisTickCount: any;
   @Input() xOrient: string = 'bottom';
+  @Input() maxTickWidth: number;
+  @Input() maxScaleTickWidth: number;
 
   @Output() dimensionsChanged = new EventEmitter();
 

--- a/src/common/axes/y-axis-ticks.component.ts
+++ b/src/common/axes/y-axis-ticks.component.ts
@@ -90,6 +90,8 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() referenceLines;
   @Input() showRefLabels: boolean = false;
   @Input() showRefLines: boolean = false;
+  @Input() maxTickHeight = 20;
+  @Input() maxScaleTickHeight = 50;
 
   @Output() dimensionsChanged = new EventEmitter();
 
@@ -221,8 +223,8 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
 
   getTicks(): any {
     let ticks;
-    const maxTicks = this.getMaxTicks(20);
-    const maxScaleTicks = this.getMaxTicks(50);
+    const maxTicks = this.getMaxTicks(this.maxTickHeight);
+    const maxScaleTicks = this.getMaxTicks(this.maxScaleTickHeight);
 
     if (this.tickValues) {
       ticks = this.tickValues;

--- a/src/common/axes/y-axis.component.ts
+++ b/src/common/axes/y-axis.component.ts
@@ -29,6 +29,8 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
         [showRefLines]="showRefLines"
         [showRefLabels]="showRefLabels"
         [height]="dims.height"
+        [maxTickHeight]="maxTickHeight"
+        [maxScaleTickHeight]="maxScaleTickHeight"
         (dimensionsChanged)="emitTicksWidth($event)"
       />
 
@@ -58,6 +60,8 @@ export class YAxisComponent implements OnChanges {
   @Input() referenceLines;
   @Input() showRefLines;
   @Input() showRefLabels;
+  @Input() maxTickHeight;
+  @Input() maxScaleTickHeight;
   @Output() dimensionsChanged = new EventEmitter();
 
   yAxisClassName: string = 'y axis';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When the screen size isn't that wide and there are too many points to plot with different values, the max number of ticks that is displayed on the x-axis and y-axis is reduced. This is because the distance between ticks use hardcoded values and in my case, the maxScaleTicks was used and only 3 ticks showed on my x-axis instead of the 13 ticks that I was expecting.

**What is the new behavior?**
When using the area-chart.component.ts, the following input properties have been exposed for the x-axis.component and y-axis.component.ts:

x-axis-ticks.component.ts
[maxTickWidth]
[maxScaleTickWidth]

y-axis-ticks.component.ts
[maxTickHeight]
[maxScaleTickHeight]

These allow the developer to specify the distance between ticks.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
In my case, I'm only using the area-chart.component.ts, so I only exposed my properties to this chart. This could be applied to all other charts.