### PR TITLE
Fix computation of X axis ticks angle

### DIFF
--- a/src/common/axes/x-axis-ticks.component.ts
+++ b/src/common/axes/x-axis-ticks.component.ts
@@ -133,7 +133,7 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   getRotationAngle(ticks): number {
     let angle = 0;
     for (let i = 0; i < ticks.length; i++) {
-      const tick = ticks[i].toString();
+      const tick = this.tickFormat(ticks[i]).toString();
       if (tick.length > this.maxTicksLength) {
         this.maxTicksLength = tick.length;
       }


### PR DESCRIPTION
Use the tick formating function to compute the X axis ticks angle.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
We are using our own X tick formatting function which reduces a date to "month/day" format, but the actual code does not use this function to compute the x axis tick angle. In our case, the tick text should not be rotated but the current implementation produces an angle of -30 or -60 deg instead.
Moreover, as a side effect, we are seeing a flickering of the line chart, as the angle changes between -30 and -60 deg continuously.

**What is the new behavior?**

The x axis tick angle is computed accordingly to the tick string displayed.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
N/A

**Other information**:
