### PR TITLE
Bump of  extract-text-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "css-loader": "^0.28.7",
     "d3": "^4.10.2",
     "emoji-flags": "^1.2.0",
-    "extract-text-webpack-plugin": "2.0.0-beta.4",
+    "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^0.11.2",
     "fs-extra": "^4.0.1",
     "gh-pages": "^1.0.0",


### PR DESCRIPTION
due to problems with AoT compilation in angular 5, the previous version of extract-text-webpack-plugin is not compatible with webpack 3 and above

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
compilation problems with AoT of Angular 5 and webpack 3

**What is the new behavior?**
clean up the compilation problems


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
