### PR TITLE
use animations for line-highlight depending on line-series animations

### DIFF
--- a/src/line-chart/line-series.component.ts
+++ b/src/line-chart/line-series.component.ts
@@ -32,6 +32,7 @@ import { sortLinear, sortByTime, sortByDomain } from '../utils/sort';
         [stops]="areaGradientStops"
         [class.active]="isActive(data)"
         [class.inactive]="isInactive(data)"
+        [animations]="animations"
       />
       <svg:g ngx-charts-line
         class="line-series"


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 
https://github.com/swimlane/ngx-charts/issues/853


**What is the new behavior?**
if `.line-heightlight` area is visible not only with user hover then it doesn't animate is there is no corresponding property on `line-series` component


**Does this PR introduce a breaking change?** 
- [ ] Yes
- [x] No


**Other information**:
