### PR TITLE
(feat): Allow configuration of label trimming on polar chart

### DIFF
--- a/docs/examples/polar-radar-chart.md
+++ b/docs/examples/polar-radar-chart.md
@@ -25,6 +25,8 @@
 | showYAxisLabel | boolean | false | show or hide the y axis label |
 | xAxisLabel | string |  | the x axis label text |
 | yAxisLabel | string |  | the y axis label text |
+| labelTrim | boolean | true | trim the labels beyond a certain maximum length |
+| labelTrimSize | number | 10 | maximum length of the labels. If `labelTrim` is `true`, labels over this length will be trimmed |
 | xAxisTickFormatting | function |  | the x axis tick formatting |
 | yAxisTickFormatting | function |  | the y axis tick formatting |
 | autoScale | boolean | false | set the minimum value of the y axis to the minimum value in the data, instead of 0 |

--- a/src/polar-chart/polar-chart.component.ts
+++ b/src/polar-chart/polar-chart.component.ts
@@ -59,7 +59,9 @@ const twoPI = 2 * Math.PI;
               [max]="outerRadius"
               [value]="showGridLines ? 1 : outerRadius"
               [explodeSlices]="true"
-              [animations]="animations">
+              [animations]="animations"
+              [labelTrim]="labelTrim"
+              [labelTrimSize]="labelTrimSize">
             </svg:g>
           </svg:g>
         </svg:g>
@@ -145,6 +147,8 @@ export class PolarChartComponent extends BaseChartComponent {
   @Input() showSeriesOnHover: boolean = true;
   @Input() gradient: boolean = false;
   @Input() yAxisMinScale: number = 0;
+  @Input() labelTrim: boolean = true;
+  @Input() labelTrimSize: number = 10;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Label on polar charts trim at 10 characters and there's no way of changing this #857 

**What is the new behavior?**
Labels on polar charts can now be configured to not trim, or a custom trim length. Omission of either results in 10 characters trimming as is current behavior.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
Closes #857