### PR TITLE
Give bar-vertical-2d a yScaleMin input

### DIFF
--- a/src/bar-chart/bar-vertical-2d.component.ts
+++ b/src/bar-chart/bar-vertical-2d.component.ts
@@ -127,6 +127,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
   @Input() roundEdges: boolean = true;
+  @Input() yScaleMin: number;
   @Input() yScaleMax: number;
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
@@ -264,7 +265,10 @@ export class BarVertical2DComponent extends BaseChartComponent {
       }
     }
 
-    const min = Math.min(0, ...domain);
+    const min = this.yScaleMin
+      ? Math.min(this.yScaleMin, ...domain)
+      : Math.min(0, ...domain);
+
     const max = this.yScaleMax
       ? Math.max(this.yScaleMax, ...domain)
       : Math.max(...domain);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently there is no yScaleMin for grouped vertical bar charts. There is yScaleMin for ungrouped bar charts.


**What is the new behavior?**
A y-axis minimum input similar to yScaleMax is added.
If yScaleMin is not set, it behaves the same as before.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
