### PR TITLE
save preformatted version of value so that countTo doesn't produce NaN

### DIFF
--- a/src/common/legend/advanced-legend.component.ts
+++ b/src/common/legend/advanced-legend.component.ts
@@ -44,7 +44,7 @@ import { formatLabel } from '../label.helper';
             <div *ngIf="animations"
               class="item-value"
               ngx-charts-count-up
-              [countTo]="legendItem.value">
+              [countTo]="legendItem._value">
             </div>
             <div *ngIf="!animations" class="item-value">
               {{legendItem.value}}
@@ -114,6 +114,7 @@ export class AdvancedLegendComponent implements OnChanges  {
       const percentage = (this.total > 0) ? value / this.total * 100 : 0;
 
       return {
+        _value: value,
         value: this.valueFormatting(value),
         color,
         label: trimLabel(this.labelFormatting(label), 20),


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

https://github.com/swimlane/ngx-charts/issues/865

**What is the new behavior?**
Fix for the above issue. Just save the value before it's formatted and use that instead of a potential string in countTo


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
