### PR TITLE
Ability to set Min and Max values for heatmaps closes #602

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -471,6 +471,8 @@
       <ngx-charts-heat-map
         *ngIf="chartType === 'heat-map'"
         class="chart-container"
+        [min]="heatmapMin"
+        [max]="heatmapMax"
         [view]="view"
         [scheme]="colorScheme"
         [results]="multi"
@@ -1106,13 +1108,21 @@
           </option>
         </select>
       </div>
-      <div *ngIf="chart.options.includes('min')">
+      <div *ngIf="chart.options.includes('min') && chart.name!='Heat Map'">
         <label>Min value:</label><br />
         <input type="number" [(ngModel)]="gaugeMin"><br />
       </div>
-      <div *ngIf="chart.options.includes('max')">
+      <div *ngIf="chart.options.includes('max')  && chart.name!='Heat Map'">
         <label>Max value:</label><br />
         <input type="number" [(ngModel)]="gaugeMax"><br />
+      </div>
+      <div *ngIf="chart.options.includes('min') && chart.name=='Heat Map'">
+        <label>Min value:</label><br />
+        <input type="number" [(ngModel)]="heatmapMin"><br />
+      </div>
+      <div *ngIf="chart.options.includes('max')  && chart.name=='Heat Map'">
+        <label>Max value:</label><br />
+        <input type="number" [(ngModel)]="heatmapMax"><br />
       </div>
       <div *ngIf="chart.options.includes('innerPadding')">
         <label>Inner padding value:</label><br />

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -176,7 +176,7 @@ export class AppComponent implements OnInit {
 
   // heatmap
   heatmapMin: number = 0;
-  heatmapMax: number = 100;
+  heatmapMax: number = 50000;
 
   // Combo Chart
   barChart: any[] = barChart;

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -174,6 +174,10 @@ export class AppComponent implements OnInit {
   gaugeValue: number = 50; // linear gauge value
   gaugePreviousValue: number = 70;
 
+  // heatmap
+  heatmapMin: number = 0;
+  heatmapMax: number = 100;
+
   // Combo Chart
   barChart: any[] = barChart;
   lineChartSeries: any[] = lineChartSeries;

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -487,7 +487,9 @@ const chartGroups = [
           'showYAxisLabel',
           'yAxisLabel',
           'innerPadding',
-          'tooltipDisabled'
+          'tooltipDisabled',
+          'min',
+          'max',
         ],
         defaults: {
           yAxisLabel: 'Census Date',

--- a/src/heat-map/heat-map.component.ts
+++ b/src/heat-map/heat-map.component.ts
@@ -87,6 +87,8 @@ export class HeatMapComponent extends BaseChartComponent {
   @Input() yAxisTicks: any[];
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipText: any;
+  @Input() min: any;
+  @Input() max: any;
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
 
@@ -133,8 +135,14 @@ export class HeatMapComponent extends BaseChartComponent {
     });
 
     if (this.scaleType === 'linear') {
-      const min = Math.min(0, ...this.valueDomain);
-      const max = Math.max(...this.valueDomain);
+      let min = this.min;
+      let max = this.max;
+      if (!this.min) {
+        min = Math.min(0, ...this.valueDomain);
+      }
+      if (!this.max) {
+        max = Math.max(...this.valueDomain);
+      }
       this.valueDomain = [min, max];
     }
 
@@ -144,7 +152,7 @@ export class HeatMapComponent extends BaseChartComponent {
     this.setColors();
     this.legendOptions = this.getLegendOptions();
 
-    this.transform = `translate(${ this.dims.xOffset } , ${ this.margin[0] })`;
+    this.transform = `translate(${this.dims.xOffset} , ${this.margin[0]})`;
     this.rects = this.getRects();
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
this is a PR for https://github.com/swimlane/ngx-charts/issues/602
previously there was no way to set min and max values for heatmaps 


**What is the new behavior?**
you can set the min as well as max for heatmap if not provided they will be calculated as before from the given data



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I'm eager to get this merged so will do the required changes if any asap
