### PR TITLE
Fixed Custom Charts Page link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ npm i @swimlane/ngx-charts --save
 ```
 
 ## Custom Charts
-To learn how to use the ngx-charts components to build custom charts and find examples, please refer to our [Custom Charts Page]
-(https://github.com/swimlane/ngx-charts/blob/master/docs/custom-charts.md).
+To learn how to use the ngx-charts components to build custom charts and find examples, please refer to our [Custom Charts Page](https://github.com/swimlane/ngx-charts/blob/master/docs/custom-charts.md).
 
 ## Credits
 `ngx-charts` is a [Swimlane](http://swimlane.com) open-source project; we believe in giving back to the open-source community by sharing some of the projects we build for our application. Swimlane is an automated cyber security operations and incident response platform that enables cyber security teams to leverage threat intelligence, speed up incident response and automate security operations.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ npm i @swimlane/ngx-charts --save
 ```
 
 ## Custom Charts
-To learn how to use the ngx-charts components to build custom charts and find examples, please refer to our [Custom Charts Page](https://github.com/swimlane/ngx-charts/blob/master/docs/intro/custom-charts.md).
+To learn how to use the ngx-charts components to build custom charts and find examples, please refer to our [Custom Charts Page]
+(https://github.com/swimlane/ngx-charts/blob/master/docs/custom-charts.md).
 
 ## Credits
 `ngx-charts` is a [Swimlane](http://swimlane.com) open-source project; we believe in giving back to the open-source community by sharing some of the projects we build for our application. Swimlane is an automated cyber security operations and incident response platform that enables cyber security teams to leverage threat intelligence, speed up incident response and automate security operations.


### PR DESCRIPTION
Replaced: https://github.com/swimlane/ngx-charts/blob/master/docs/intro/custom-charts.md

With: https://github.com/swimlane/ngx-charts/blob/master/docs/custom-charts.md

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Current link to the Custom Charts Page doesn't resolve properly.


**What is the new behavior?**
Link resolves to the correct URL.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
