### PR TITLE
Added export for domain.helper

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -20,3 +20,4 @@ export * from './tick-format.helper';
 export * from './trim-label.helper';
 export * from './view-dimensions.helper';
 export * from './label.helper';
+export * from './domain.helper';


### PR DESCRIPTION
A user pointed out that the domain.helper function is not being exported in [this issue](https://github.com/swimlane/ngx-charts/issues/882)

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
