### PR TITLE
Add bar-max-width for vertical-bar-chart

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -26,6 +26,7 @@
         [roundEdges]="roundEdges"
         [yScaleMax]="yScaleMax"
         [showDataLabel]="showDataLabel"
+		[barMaxWidth]="barMaxWidth"
         (select)="select($event)"
         (legendLabelClick)="onLegendLabelClick($event)">
       </ngx-charts-bar-vertical>

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -96,6 +96,7 @@ export class AppComponent implements OnInit {
   yScaleMin: number;
   yScaleMax: number;
   showDataLabel = false;
+  barMaxWidth:number;
 
   curves = {
     Basis: shape.curveBasis,

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -25,7 +25,8 @@ const chartGroups = [
           'tooltipDisabled',
           'roundEdges',
           'yScaleMax',
-          'showDataLabel'
+          'showDataLabel',
+          'barMaxWidth'
         ]
       },
       {

--- a/src/bar-chart/bar-vertical.component.spec.ts
+++ b/src/bar-chart/bar-vertical.component.spec.ts
@@ -126,4 +126,35 @@ describe('<ngx-charts-bar-vertical>', () => {
       });
     }));
   });
+
+  describe('bar-max-width', () => {
+
+    it('should render correct cell size, with zero padding, but fixed width', async(() => {
+      TestBed.overrideComponent(TestComponent, {
+        set: {
+          template: `
+               <ngx-charts-bar-vertical
+                [view]="[400,800]"
+                [scheme]="colorScheme"
+                [results]="single"
+                [barPadding]="0"
+                [barMaxWidth]="30">
+              </ngx-charts-bar-vertical>`
+        }
+      });
+
+      TestBed.compileComponents().then(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+
+        const bar = fixture.debugElement.query(By.directive(BarComponent));
+
+        expect(bar.componentInstance.width).toEqual(30); 
+      });
+    }));
+
+  });
+
+
+
 });

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -102,6 +102,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Input() yScaleMin: number;
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
+  @Input() barMaxWidth: number;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -158,9 +159,12 @@ export class BarVerticalComponent extends BaseChartComponent {
   getXScale(): any {
     this.xDomain = this.getXDomain();
     const spacing = this.xDomain.length / (this.dims.width / this.barPadding + 1);
+    const maxWidth = Math.min( this.barMaxWidth *  this.xDomain.length,  this.dims.width);
+
     return scaleBand()
-      .rangeRound([0, this.dims.width])
+      .rangeRound([0, this.barMaxWidth ? maxWidth :  this.dims.width])
       .paddingInner(spacing)
+      .align(0)
       .domain(this.xDomain);
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The bars in a vertical bar chart always span the entire width of the chart.  even when there is only one bar, which can be aesthetically displeasing


**What is the new behavior?**
When the new [barMaxWidth] is added to the chart, no single bar will be wider than the supplied value.  
If the total of all bars is larger than the view port or a value is not supplied, the normal width logic is used.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Issue #831