### PR TITLE
Fix value formatting for advanced-legend

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -238,6 +238,7 @@
         [view]="view"
         [scheme]="colorScheme"
         [results]="single"
+        [valueFormatting]="valueFormatting"
         [animations]="animations"
         (legendLabelClick)="onLegendLabelClick($event)"
         [gradient]="gradient"

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -565,6 +565,10 @@ export class AppComponent implements OnInit {
     }
   }
 
+  valueFormatting(v: number): string {
+    return `${Math.round(v).toLocaleString()} €`;
+  }
+
   currencyFormatting(c) {
     return `\$${Math.round(c.value).toLocaleString()}`;
   }

--- a/src/common/legend/advanced-legend.component.ts
+++ b/src/common/legend/advanced-legend.component.ts
@@ -20,10 +20,11 @@ import { formatLabel } from '../label.helper';
         *ngIf="animations"
         class="total-value"
         ngx-charts-count-up
-        [countTo]="roundedTotal">
+        [countTo]="roundedTotal" 
+        [valueFormatting]="valueFormatting">
       </div>
-      <div *ngIf="!animations">
-        {{roundedTotal}}
+      <div class="total-value" *ngIf="!animations">
+        {{valueFormatting(roundedTotal)}}
       </div>
       <div class="total-label">
         {{label}}
@@ -44,10 +45,11 @@ import { formatLabel } from '../label.helper';
             <div *ngIf="animations"
               class="item-value"
               ngx-charts-count-up
-              [countTo]="legendItem.value">
+              [countTo]="legendItem.value"
+              [valueFormatting]="valueFormatting">
             </div>
             <div *ngIf="!animations" class="item-value">
-              {{legendItem.value}}
+              {{valueFormatting(legendItem.value)}}
             </div>
             <div class="item-label">{{legendItem.label}}</div>
             <div *ngIf="animations"
@@ -114,7 +116,7 @@ export class AdvancedLegendComponent implements OnChanges  {
       const percentage = (this.total > 0) ? value / this.total * 100 : 0;
 
       return {
-        value: this.valueFormatting(value),
+        value,
         color,
         label: trimLabel(this.labelFormatting(label), 20),
         originalLabel: d.name,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Value formatting (e.g. adding a currency symbol) does not work for legend of ngx-charts-advanced-pie-chart if animations are enabled (see issue #865) and is not applied to its total value (see issue #794). 

**What is the new behavior?**

Value formatting works on values and total value with and without animations enabled.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: