### PR TITLE
Fix advanced-legend colors in print

### DIFF
--- a/src/common/legend/advanced-legend.component.scss
+++ b/src/common/legend/advanced-legend.component.scss
@@ -56,6 +56,7 @@
         }
 
         .item-color {
+          border-left: 4px solid;
           width: 4px;
           height: 42px;
           float: left;

--- a/src/common/legend/advanced-legend.component.ts
+++ b/src/common/legend/advanced-legend.component.ts
@@ -39,7 +39,7 @@ import { formatLabel } from '../label.helper';
             (click)="select.emit({ name: legendItem.label, value: legendItem.value })">
             <div
               class="item-color"
-              [style.background]="legendItem.color">
+              [style.border-left-color]="legendItem.color">
             </div>
             <div *ngIf="animations"
               class="item-value"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Colors are missing in advanced-legend when printing charts (see issue #784) because browsers ignore the css property background-color when printing.

**What is the new behavior?**

By using a border instead of background-color for displaying colors in the legend these are now also shown in print. This fix works at least for Chrome 67 and Firefox 61 and it should also work for other browsers but I haven't tried it.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: