### PR TITLE
yScaleMin atribute added to 'ngx-charts-bar-vertical-stacked'

### DIFF
--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -119,6 +119,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() yAxisTicks: any[];
   @Input() barPadding = 8;
   @Input() roundDomains: boolean = false;
+  @Input() yScaleMin: number;
   @Input() yScaleMax: number;
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
@@ -228,7 +229,9 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
     domain.push(smallest);
     domain.push(biggest);
 
-    const min = Math.min(0, ...domain);
+    const min = this.yScaleMin
+      ? Math.min(this.yScaleMin, ...domain)
+      : Math.min(0, ...domain);
     const max = this.yScaleMax
       ? Math.max(this.yScaleMax, ...domain)
       : Math.max(...domain);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
now is not posible set the min value for the Y axis in "ngx-charts-bar-vertical-stacked" and in some situation someone can need it. for example me. 


**What is the new behavior?**
is posible to set the min value for Y axis with component input named "yScaleMin" for  "ngx-charts-bar-vertical-stacked".
example:
 
<ngx-charts-bar-vertical-stacked
              [scheme]="onlineVsOfflineByGroupNameWidget.scheme"
              [results]="onlineVsOfflineByGroupNameWidget.data"
             [yScaleMin]="10"
              (select)="onlineVsOfflineByGroupNameWidget.onSelect($event)">
</ngx-charts-bar-vertical-stacked>

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
