### PR TITLE
Remove Angular location strategy from ChartCommonModule

### DIFF
--- a/src/common/chart-common.module.ts
+++ b/src/common/chart-common.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy, CommonModule } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 import { ChartComponent } from './charts/chart.component';
 import {
@@ -39,13 +39,6 @@ const COMPONENTS = [
 ];
 
 @NgModule({
-  providers: [
-    Location,
-    {
-      provide: LocationStrategy,
-      useClass: PathLocationStrategy
-    }
-  ],
   imports: [
     CommonModule,
     AxesModule,


### PR DESCRIPTION
The hardcoded PathLocationStrategy changes the routing behavior of Angular
applications. This causes issues, as it potentially overwrites the intended
routing strategy. This is especially problematic for lazy loaded modules, where
the proposed workaround (reordering of modules) doesn't work. In those cases,
an ugly hack is needed that sets the location strategy explicitely in every
lazy loaded module.

For more information, see https://github.com/swimlane/ngx-charts/issues/601

Please keep in mind, that this change may break existing applications, that
unknowingly rely on the "pre-configured" location strategy provided by
ngx-charts. In case this pull request gets merged, at least a notice should
be left in the documentation / change logs / github page.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-charts/issues/601


**What is the new behavior?**
The routing strategy of Angular applications is no more affected by the usage of ngx-charts.


**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes (for some applications)
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Angular applications, that unknowingly rely on the "pre-configured" location strategy provided by
ngx-charts, may be affected by this change. In case this pull request gets merged, at least a notice should be left in the documentation / change logs / github page.

**Other information**:
