### PR TITLE
Remove duplicated exports

### DIFF
--- a/src/area-chart/area-chart.module.ts
+++ b/src/area-chart/area-chart.module.ts
@@ -5,13 +5,6 @@ import { AreaChartStackedComponent } from './area-chart-stacked.component';
 import { AreaSeriesComponent } from './area-series.component';
 import { ChartCommonModule } from '../common/chart-common.module';
 
-export { 
-  AreaChartComponent, 
-  AreaChartNormalizedComponent, 
-  AreaChartStackedComponent, 
-  AreaSeriesComponent 
-};
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/bar-chart/bar-chart.module.ts
+++ b/src/bar-chart/bar-chart.module.ts
@@ -13,14 +13,6 @@ import { SeriesHorizontal } from './series-horizontal.component';
 import { SeriesVerticalComponent } from './series-vertical.component';
 import { BarLabelComponent } from './bar-label.component';
 
-export {
-  BarLabelComponent, BarComponent, BarHorizontalComponent, BarHorizontal2DComponent,
-  BarHorizontalNormalizedComponent, BarHorizontalStackedComponent,
-  BarVerticalComponent, BarVertical2DComponent,
-  BarVerticalNormalizedComponent, BarVerticalStackedComponent, SeriesHorizontal,
-  SeriesVerticalComponent 
-};
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/bubble-chart/bubble-chart.module.ts
+++ b/src/bubble-chart/bubble-chart.module.ts
@@ -3,8 +3,6 @@ import { ChartCommonModule } from '../common/chart-common.module';
 import { BubbleChartComponent } from './bubble-chart.component';
 import { BubbleSeriesComponent } from './bubble-series.component';
 
-export { BubbleChartComponent, BubbleSeriesComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/force-directed-graph/force-directed-graph.module.ts
+++ b/src/force-directed-graph/force-directed-graph.module.ts
@@ -2,8 +2,6 @@ import { NgModule } from '@angular/core';
 import { ForceDirectedGraphComponent } from './force-directed-graph.component';
 import { ChartCommonModule } from '../common/chart-common.module';
 
-export { ForceDirectedGraphComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/gauge/gauge.module.ts
+++ b/src/gauge/gauge.module.ts
@@ -7,8 +7,6 @@ import { GaugeAxisComponent } from './gauge-axis.component';
 import { PieChartModule } from '../pie-chart/pie-chart.module';
 import { BarChartModule } from '../bar-chart/bar-chart.module';
 
-export { GaugeComponent, GaugeArcComponent, GaugeAxisComponent, LinearGaugeComponent };
-
 @NgModule({
   imports: [ChartCommonModule, PieChartModule, BarChartModule],
   declarations: [

--- a/src/heat-map/heat-map.module.ts
+++ b/src/heat-map/heat-map.module.ts
@@ -4,8 +4,6 @@ import { HeatMapCellComponent } from './heat-map-cell.component';
 import { HeatCellSeriesComponent } from './heat-map-cell-series.component';
 import { HeatMapComponent } from './heat-map.component';
 
-export { HeatMapCellComponent, HeatCellSeriesComponent, HeatMapComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/line-chart/line-chart.module.ts
+++ b/src/line-chart/line-chart.module.ts
@@ -4,8 +4,6 @@ import { LineComponent } from './line.component';
 import { LineChartComponent } from './line-chart.component';
 import { LineSeriesComponent } from './line-series.component';
 
-export { LineComponent, LineChartComponent, LineSeriesComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/number-card/number-card.module.ts
+++ b/src/number-card/number-card.module.ts
@@ -4,8 +4,6 @@ import { CardComponent } from './card.component';
 import { CardSeriesComponent } from './card-series.component';
 import { NumberCardComponent } from './number-card.component';
 
-export { CardComponent, CardSeriesComponent, NumberCardComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/pie-chart/index.ts
+++ b/src/pie-chart/index.ts
@@ -4,4 +4,3 @@ export * from './pie-arc.component';
 export * from './pie-grid.component';
 export * from './pie-series.component';
 export * from './pie-label.component';
-export * from './pie-series.component';

--- a/src/pie-chart/pie-chart.module.ts
+++ b/src/pie-chart/pie-chart.module.ts
@@ -8,12 +8,6 @@ import { PieGridComponent } from './pie-grid.component';
 import { PieGridSeriesComponent } from './pie-grid-series.component';
 import { PieSeriesComponent } from './pie-series.component';
 
-export {
-  AdvancedPieChartComponent, PieLabelComponent, PieArcComponent,
-  PieChartComponent, PieGridComponent, PieGridSeriesComponent,
-  PieSeriesComponent
-};
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [

--- a/src/polar-chart/polar-chart.module.ts
+++ b/src/polar-chart/polar-chart.module.ts
@@ -5,8 +5,6 @@ import { PolarSeriesComponent } from './polar-series.component';
 import { PieChartModule } from '../pie-chart/';
 import { LineChartModule } from '../line-chart/';
 
-export { PolarChartComponent, PolarSeriesComponent };
-
 @NgModule({
   imports: [ChartCommonModule, PieChartModule, LineChartModule],
   declarations: [

--- a/src/tree-map/tree-map.module.ts
+++ b/src/tree-map/tree-map.module.ts
@@ -4,8 +4,6 @@ import { TreeMapCellComponent } from './tree-map-cell.component';
 import { TreeMapCellSeriesComponent } from './tree-map-cell-series.component';
 import { TreeMapComponent } from './tree-map.component';
 
-export { TreeMapCellComponent, TreeMapCellSeriesComponent, TreeMapComponent };
-
 @NgModule({
   imports: [ChartCommonModule],
   declarations: [


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?**
Currently all the components are exported twice:
- via `index.ts` files
- via `module.ts` files

**What is the new behavior?**
Components are exported only once, via `index.ts` files. That's the common angular package behavior to export components via the `index.ts` or `public_api.ts` files.

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No

**Other information**:

This issue causes errors when used with Server Side Rendering and is preventing us from using the package.

**Scenario:**
- Install package.
- Apply workaround described [here](https://github.com/swimlane/ngx-charts/issues/18#issuecomment-405571689).
- Run application with SSR enabled.

**Result:** Angular fails with the duplicate imports error.

P.S. The unit test reported by Travis was broken before my change.