### PR TITLE
Fix invalid ColorHelper type import

### DIFF
--- a/src/common/circle-series.component.ts
+++ b/src/common/circle-series.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/animations';
 import { formatLabel } from '../common/label.helper';
 import { id } from '../utils/id';
-import { ColorHelper } from '.';
+import { ColorHelper } from '../common/color.helper';
 
 @Component({
   selector: 'g[ngx-charts-circle-series]',


### PR DESCRIPTION
Fixes #855

**What kind of change does this PR introduce?** (check one with "x")
- Bugfix

**What is the current behavior?**
**What is the new behavior?**
There is a typo in imports and it's fixed in this PR.
See #855 for more detail.

**Does this PR introduce a breaking change?** (check one with "x")
- No


**Other information**:
This issue prevents us from using this library, as it fails when Angular Server Side Rendering feature is used.

P.S. The unit test reported by Travis was broken before my change.