### PR TITLE
Add MouseEvent workaround for the Server Side Rendering

### DIFF
--- a/src/common/tooltip-area.component.ts
+++ b/src/common/tooltip-area.component.ts
@@ -14,6 +14,7 @@ import {
   animate,
   transition
 } from '@angular/animations';
+import { MouseEvent } from '../events';
 
 @Component({
   selector: 'g[ngx-charts-tooltip-area]',

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,15 @@
+declare let global: any;
+
+// If we don't check whether 'window' and 'global' variables are defined,
+// code will fail in browser/node with 'variable is undefined' error.
+let root: any;
+if (typeof(window) !== 'undefined') {
+  root = window;
+} else if (typeof(global) !== 'undefined') {
+  root = global;
+}
+
+/* tslint:disable:variable-name */
+export const MouseEvent = root.MouseEvent as MouseEvent & {
+  new (typeArg: string, eventInitDict?: MouseEventInit): MouseEvent;
+};

--- a/src/force-directed-graph/force-directed-graph.component.ts
+++ b/src/force-directed-graph/force-directed-graph.component.ts
@@ -24,6 +24,7 @@ import { ChartComponent } from '../common/charts/chart.component';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
+import { MouseEvent } from '../events';
 
 @Component({
   selector: 'ngx-charts-force-directed-graph',

--- a/src/pie-chart/pie-arc.component.ts
+++ b/src/pie-chart/pie-arc.component.ts
@@ -13,6 +13,7 @@ import { select } from 'd3-selection';
 import { arc } from 'd3-shape';
 
 import { id } from '../utils/id';
+import { MouseEvent } from '../events';
 
 @Component({
   selector: 'g[ngx-charts-pie-arc]',


### PR DESCRIPTION
Node doesn't contain `MouseEvent` type definition and package fails if is imported by the Angular Server Side Rendering module. Here we add a workaround and import MouseEvent type from the place where it exists.

Fixes #460 Fixes #572 

**What kind of change does this PR introduce?** (check one with "x")
- Bugfix

**What is the current behavior?**
**What is the new behavior?**
See #460 for more detail


**Does this PR introduce a breaking change?**
- No

**Other information**:
This issue prevents us from using this library, as it fails when Angular Server Side Rendering feature is used. It's a critical one for us 😟 

I tried to copy `events.ts` without changes from here:
https://github.com/swimlane/ngx-datatable/blob/7b0d6359fd0298f726eb15dabc392cef1c2dc2a6/src/events.ts#L4
However, it fails during execution with `window is undefined` when run by Node. With my code is works perfect both at server and client side.

P.S. The unit test reported by Travis was broken before my change.