### PR TITLE
add missing exports

### DIFF
--- a/src/bar-chart/bar-label.component.ts
+++ b/src/bar-chart/bar-label.component.ts
@@ -8,7 +8,7 @@ import {
     Output,    
     EventEmitter
   } from '@angular/core';
-import { formatLabel } from '..';
+import { formatLabel } from '../common/label.helper';
   
 @Component({
   selector: 'g[ngx-charts-bar-label]',

--- a/src/bar-chart/index.ts
+++ b/src/bar-chart/index.ts
@@ -6,6 +6,8 @@ export * from './bar-horizontal-normalized.component';
 export * from './bar-horizontal-stacked.component';
 export * from './series-horizontal.component';
 
+export * from './bar-label.component';
+
 export * from './bar-vertical.component';
 export * from './bar-vertical-2d.component';
 export * from './bar-vertical-normalized.component';

--- a/src/bubble-chart/index.ts
+++ b/src/bubble-chart/index.ts
@@ -1,3 +1,4 @@
 export * from './bubble-chart.module';
 export * from './bubble-chart.component';
+export * from './bubble-chart.utils';
 export * from './bubble-series.component';

--- a/src/gauge/index.ts
+++ b/src/gauge/index.ts
@@ -1,2 +1,5 @@
 export * from './gauge.module';
+export * from './gauge-arc.component';
+export * from './gauge-axis.component';
 export * from './gauge.component';
+export * from './linear-gauge.component';

--- a/src/pie-chart/index.ts
+++ b/src/pie-chart/index.ts
@@ -1,4 +1,5 @@
 export * from './pie-chart.module';
+export * from './advanced-pie-chart.component';
 export * from './pie-chart.component';
 export * from './pie-arc.component';
 export * from './pie-grid.component';


### PR DESCRIPTION
add missing exports to index.ts in bar-chart, bubble-chart, gauge, pie-chart
also, correct an import of formatLabel in bar-label.component which was causing rollup bundling to fail

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

restores some exports missing since this [PR](https://github.com/swimlane/ngx-charts/pull/919)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No
