### PR TITLE
Improved axes ticks visualization

### DIFF
--- a/src/common/axes/x-axis-ticks.component.ts
+++ b/src/common/axes/x-axis-ticks.component.ts
@@ -10,6 +10,7 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { cssValidName } from '../css-class.helper';
 import { trimLabel } from '../trim-label.helper';
 import { reduceTicks } from './ticks.helper';
 
@@ -34,8 +35,9 @@ import { reduceTicks } from './ticks.helper';
       [attr.transform]="tickTransform(tick)">
       <svg:g *ngIf="showGridLines"
         [attr.transform]="gridLineTransform()">
-        <svg:line
+        <svg:line          
           class="gridline-path gridline-path-vertical"
+          [ngClass]="tickClass(tick)"
           [attr.y1]="-gridLineHeight"
           y2="0" />
       </svg:g>
@@ -175,6 +177,10 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   getMaxTicks(tickWidth: number): number {
     return Math.floor(this.width / tickWidth);
   }
+
+  tickClass(tick): string {    
+    return `x-tick-${cssValidName(trimLabel(this.tickFormat(tick)))}`;
+  }  
 
   tickTransform(tick): string {
     return 'translate(' + this.adjustedScale(tick) + ',' + this.verticalSpacing + ')';

--- a/src/common/axes/y-axis-ticks.component.ts
+++ b/src/common/axes/y-axis-ticks.component.ts
@@ -10,6 +10,7 @@ import {
   ChangeDetectionStrategy,
   SimpleChanges
 } from '@angular/core';
+import { cssValidName } from '../css-class.helper';
 import { trimLabel } from '../trim-label.helper';
 import { reduceTicks } from './ticks.helper';
 import { roundedRect } from '../../common/shape.helper';
@@ -43,12 +44,14 @@ import { roundedRect } from '../../common/shape.helper';
       <svg:g
         *ngIf="showGridLines"
         [attr.transform]="gridLineTransform()">
-        <svg:line *ngIf="orient === 'left'"
+        <svg:line *ngIf="orient === 'left'"          
           class="gridline-path gridline-path-horizontal"
+          [ngClass]="tickClass(tick)"
           x1="0"
           [attr.x2]="gridLineWidth" />
         <svg:line *ngIf="orient === 'right'"
           class="gridline-path gridline-path-horizontal"
+          [ngClass]="tickClass(tick)"
           x1="0"
           [attr.x2]="-gridLineWidth" />
       </svg:g>
@@ -239,6 +242,10 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   getMaxTicks(tickHeight: number): number {
     return Math.floor(this.height / tickHeight);
   }
+
+  tickClass(tick): string {    
+    return `y-tick-${cssValidName(trimLabel(this.tickFormat(tick)))}`;
+  }  
 
   tickTransform(tick): string {
     return `translate(${this.adjustedScale(tick)},${this.verticalSpacing})`;

--- a/src/common/css-class.helper.ts
+++ b/src/common/css-class.helper.ts
@@ -1,0 +1,10 @@
+/**
+ * Return a css-valid name starting from a string
+ *
+ * @export
+ * @returns string
+ * @param sourceName
+ */
+export function cssValidName(sourceName): string {
+  return sourceName ? sourceName.replace(/[^\w\s]/gi, '').replace(' ', '-').toLowerCase() : '';
+}

--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -281,7 +281,10 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getXDomain(): any[] {
-    let values = getUniqueXDomainValues(this.results);
+    const results = this.results || [];
+    const ticks = this.xAxisTicks || [];
+
+    let values = [...getUniqueXDomainValues(results), ...ticks];
 
     this.scaleType = this.getScaleType(values);
     let domain = [];
@@ -293,11 +296,11 @@ export class LineChartComponent extends BaseChartComponent {
     let min;
     let max;
     if (this.scaleType === 'time' || this.scaleType === 'linear') {
-      min = this.xScaleMin
+      min = !this.isNullOrUndefined(this.xScaleMin)
         ? this.xScaleMin
         : Math.min(...values);
 
-      max = this.xScaleMax
+      max = !this.isNullOrUndefined(this.xScaleMax)
         ? this.xScaleMax
         : Math.max(...values);
     }
@@ -345,16 +348,17 @@ export class LineChartComponent extends BaseChartComponent {
       }
     }
 
-    const values = [...domain];
+    const ticks = this.yAxisTicks || [];
+    const values = [...domain, ...ticks];
     if (!this.autoScale) {
       values.push(0);
     }
 
-    const min = this.yScaleMin
+    const min = !this.isNullOrUndefined(this.yScaleMin)
       ? this.yScaleMin
       : Math.min(...values);
 
-    const max = this.yScaleMax
+    const max = !this.isNullOrUndefined(this.yScaleMax)
       ? this.yScaleMax
       : Math.max(...values);
 
@@ -399,6 +403,8 @@ export class LineChartComponent extends BaseChartComponent {
   }
 
   getScaleType(values): string {
+    if (this.isEmptyOrFalsyArray(values)) return 'ordinal';
+
     let date = true;
     let num = true;
 
@@ -415,6 +421,18 @@ export class LineChartComponent extends BaseChartComponent {
     if (date) return 'time';
     if (num) return 'linear';
     return 'ordinal';
+  }
+
+  isEmptyOrFalsyArray(arr): boolean {
+    return !Array.isArray(arr) || !arr.length;
+  }
+
+  isNullOrUndefined(val) {
+    return val === null || val === undefined;
+  } 
+
+  isValidRange(min, max) {
+    return !this.isNullOrUndefined(min) && !this.isNullOrUndefined(max);
   }
 
   isDate(value): boolean {


### PR DESCRIPTION
Improved axes ticks visualization when there are no chart data.
Value of 0 for xScaleMin, xScaleMax, yScaleMin, yScaleMax is now handled

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

I attached a patch to recreate the issue scenario in the demo (line chart section).

[issue-scenario-patch.txt](https://github.com/swimlane/ngx-charts/files/2245352/issue-scenario-patch.txt)

Axes are not show correctly even if I use pre-defined ticks as input:
![before-patch](https://user-images.githubusercontent.com/910075/43461104-e72a64a6-94d2-11e8-9c18-fa775b9bac75.png)

**What is the new behavior?**

![after-patch](https://user-images.githubusercontent.com/910075/43461107-ec9828ba-94d2-11e8-8acd-939e9c079516.png)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: