### PR TITLE
Added optional upper boundary stroke for area sections in area charts

### DIFF
--- a/src/area-chart/area-chart-normalized.component.ts
+++ b/src/area-chart/area-chart-normalized.component.ts
@@ -62,13 +62,15 @@ import { getUniqueXDomainValues } from '../common/domain.helper';
           (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
         <svg:g [attr.clip-path]="clipPath">
-          <svg:g *ngFor="let series of results; trackBy:trackBy">
+          <svg:g *ngFor="let series of results; let ind = index; trackBy:trackBy">
             <svg:g ngx-charts-area-series
+              [index]="ind"
               [xScale]="xScale"
               [yScale]="yScale"
               [colors]="colors"
               [data]="series"
               [scaleType]="scaleType"
+              [enableStroke]="enableStroke"
               [activeEntries]="activeEntries"
               [gradient]="gradient"
               normalized="true"
@@ -164,6 +166,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
   @Input() yAxisTicks: any[];
   @Input() roundDomains: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() enableStroke: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/area-chart/area-chart-stacked.component.ts
+++ b/src/area-chart/area-chart-stacked.component.ts
@@ -62,11 +62,13 @@ import { getUniqueXDomainValues } from '../common/domain.helper';
           (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
         <svg:g [attr.clip-path]="clipPath">
-          <svg:g *ngFor="let series of results; trackBy:trackBy">
+          <svg:g *ngFor="let series of results; let ind = index; trackBy:trackBy">
             <svg:g ngx-charts-area-series
+              [index]="ind"
               [xScale]="xScale"
               [yScale]="yScale"
               [colors]="colors"
+              [enableStroke]="enableStroke"
               [data]="series"
               [scaleType]="scaleType"
               [gradient]="gradient"
@@ -167,6 +169,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
   @Input() xScaleMax: any;
   @Input() yScaleMin: number;
   @Input() yScaleMax: number;
+  @Input() enableStroke: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -62,11 +62,13 @@ import { getUniqueXDomainValues } from '../common/domain.helper';
           (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
         <svg:g [attr.clip-path]="clipPath">
-          <svg:g *ngFor="let series of results; trackBy:trackBy">
+          <svg:g *ngFor="let series of results; let ind = index; trackBy:trackBy">
             <svg:g ngx-charts-area-series
+              [index]="ind"
               [xScale]="xScale"
               [yScale]="yScale"
               [baseValue]="baseValue"
+              [enableStroke]="enableStroke"
               [colors]="colors"
               [data]="series"
               [activeEntries]="activeEntries"
@@ -169,6 +171,7 @@ export class AreaChartComponent extends BaseChartComponent {
   @Input() xScaleMax: any;
   @Input() yScaleMin: number;
   @Input() yScaleMax: number;
+  @Input() enableStroke: boolean = true;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/common/base-chart.component.scss
+++ b/src/common/base-chart.component.scss
@@ -109,4 +109,18 @@
     }
   }
 
+  .ngx-charts-area-boundary {
+    opacity: 0;
+    stroke-width: 2;
+    animation-name: animateStroke;
+    animation-duration: 0.4s;
+    animation-iteration-count: 1;
+    animation-delay: 1s;
+    animation-fill-mode: forwards;
+  }
+
+  @keyframes animateStroke {
+    from {opacity:0}
+    to {opacity:1}
+  }
 }

--- a/src/common/color.helper.ts
+++ b/src/common/color.helper.ts
@@ -161,4 +161,21 @@ export class ColorHelper {
 
     return stops;
   }
+
+  getBoundaryColor(color, percent) {
+    const f = parseInt(color.slice(1), 16);
+    const t = percent < 0 ? 0 : 255;
+    const p = percent < 0 ? percent * -1 : percent;
+    const R = f >> 16;
+    const G = f >> 8 & 0x00FF;
+    const B = f & 0x0000FF;
+    let partA = 0x1000000;
+    partA += (Math.round((t - R) * p) + R) * 0x10000 + (Math.round((t - G) * p) + G) * 0x100;
+    partA += (Math.round((t - B) * p) + B);
+    return '#' + partA.toString(16).slice(1);
+  }
+  /**
+   * Returns a shade of color which is lighter/darker from input color (Hex format) by a given percentage
+   * percent input ranges from -1.0 (black) to 1.0 (white)
+   */
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Added new feature. Linking the feature request: [https://github.com/swimlane/ngx-charts/issues/967](url)


**What is the new behavior?** 

- User can pass an optional boolean param **enableStroke** to enable/disable  rendering of upper boundary path for area segments in area charts (enabled by default).
- Added functionality to assign by default a slightly darker color for stroke which is generated from corresponding fill color for the area segment.
- Also provide classes for eg. **area-boundary-{index}** to allow user to customize attributes of stroke path.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
