### PR TITLE
Added accessibility attributes to bar charts

### DIFF
--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -26,8 +26,11 @@ import { id } from '../utils/id';
     <svg:path
       class="bar"
       stroke="none"
+      role="img"
+      tabIndex="-1"
       [class.active]="isActive"
       [attr.d]="path"
+      [attr.aria-label]="ariaLabel"
       [attr.fill]="hasGradient ? gradientFill : fill"
       (click)="select.emit(data)"
     />
@@ -49,6 +52,7 @@ export class BarComponent implements OnChanges {
   @Input() isActive: boolean = false;
   @Input() stops: any[];
   @Input() animations: boolean = true;
+  @Input() ariaLabel: string;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();

--- a/src/bar-chart/series-horizontal.component.ts
+++ b/src/bar-chart/series-horizontal.component.ts
@@ -35,6 +35,7 @@ import { D0Types } from './series-vertical.component';
       (select)="click($event)"
       [gradient]="gradient"
       [isActive]="isActive(bar.data)"
+      [ariaLabel]="bar.ariaLabel"
       [animations]="animations"
       (activate)="activate.emit($event)"
       (deactivate)="deactivate.emit($event)"
@@ -190,9 +191,11 @@ export class SeriesHorizontal implements OnChanges {
       }
 
       let tooltipLabel = formattedLabel;
+      bar.ariaLabel = formattedLabel + ' ' + value.toLocaleString();
       if (this.seriesName) {
         tooltipLabel = `${this.seriesName} • ${formattedLabel}`;
         bar.data.series = this.seriesName;
+        bar.ariaLabel = this.seriesName + ' ' +  bar.ariaLabel;
       }
 
       bar.tooltipText = this.tooltipDisabled ? undefined : `

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -37,6 +37,7 @@ export enum D0Types {
       [orientation]="'vertical'"
       [roundEdges]="bar.roundEdges"
       [gradient]="gradient"
+      [ariaLabel]="bar.ariaLabel"
       [isActive]="isActive(bar.data)"
       (select)="onClick($event)"
       (activate)="activate.emit($event)"
@@ -203,9 +204,11 @@ export class SeriesVerticalComponent implements OnChanges {
       }
 
       let tooltipLabel = formattedLabel;
+      bar.ariaLabel = formattedLabel + ' ' + value.toLocaleString();
       if (this.seriesName) {
         tooltipLabel = `${this.seriesName} • ${formattedLabel}`;
         bar.data.series = this.seriesName;
+        bar.ariaLabel = this.seriesName + ' ' +  bar.ariaLabel;
       }
 
       bar.tooltipText = this.tooltipDisabled ? undefined : `


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When tabbing to the first bar in the bar graph chart, JAWS screen reader reads the highest y-axis value in the page instead of the value of the currently focused bar. It again repeats this same value for all bars in the chart.


**What is the new behavior?**
When tabbing to the first bar in the bar graph chart, JAWS screen reader reads the value of the currently selected bar, not the highest value in the graph. This behavior would be consistent with every bar in the table.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This PR refers to #945  as the original feature request. Please suggest any changes required in the implementation.