### PR TITLE
Add id for chartArea in line charts

### DIFF
--- a/src/line-chart/line-chart.component.ts
+++ b/src/line-chart/line-chart.component.ts
@@ -70,7 +70,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
           [showRefLabels]="showRefLabels"
           (dimensionsChanged)="updateYAxisWidth($event)">
         </svg:g>
-        <svg:g [attr.clip-path]="clipPath">
+        <svg:g [attr.clip-path]="clipPath" id="chartArea">
           <svg:g *ngFor="let series of results; trackBy:trackBy" [@animationState]="'active'">
             <svg:g ngx-charts-line-series
               [xScale]="xScale"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Chart area for line charts has no id.


**What is the new behavior?**
Chart area for line charts has an id. To be able to draw additional elements into a chart area. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
I'm trying to draw a vertical line which highlights a date and I'm trying to select the element with d3-select. This is the only way I found that works, like I want it.