### PR TITLE
Fix memory leak due to permanent reference from service to component

### DIFF
--- a/src/common/tooltip/injection.service.ts
+++ b/src/common/tooltip/injection.service.ts
@@ -47,11 +47,9 @@ export class InjectionService {
    * @memberOf InjectionService
    */
   getRootViewContainer(): ComponentRef<any> {
-    const rootComponents = this.applicationRef.components;
-
-    // fix cannot read length of undefined
-    if (rootComponents) {
-      if (rootComponents.length) return rootComponents[0];
+    const appRootComponent = this.tryGetRootApplicationComponent();
+    if (appRootComponent) {
+      return appRootComponent;
     }
 
     if (this._container) return this._container;
@@ -61,14 +59,19 @@ export class InjectionService {
   }
 
   /**
-   * Overrides the default root view container. This is useful for
-   * things like ngUpgrade that doesn't have a ApplicationRef root.
+   * Set the fallback container if application root component is not defined.
+   * This is useful for things like ngUpgrade that doesn't have a ApplicationRef root.
    *
    * @param {any} container
    *
    * @memberOf InjectionService
    */
   setRootViewContainer(container): void {
+    // Do not store reference if we have ApplicationRef root, as we are not using that value anyway.
+    if (this.tryGetRootApplicationComponent()) {
+      return;
+    }
+
     this._container = container;
   }
 
@@ -162,5 +165,15 @@ export class InjectionService {
     renderer.appendChild(location, componentRootNode);
 
     return componentRef;
+  }
+
+  private tryGetRootApplicationComponent() {
+    const rootComponents = this.applicationRef.components;
+    // rootComponents might be undefined.
+    if (rootComponents && rootComponents.length) {
+      return rootComponents[0];
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If you add a chart to the component and later destroy the component, it's still alive due to `ComponentRef<>` reference in the service.

**What is the new behavior?**
Memory leak is fixed and doesn't happen if application has `ApplicationRef` root.

**Does this PR introduce a breaking change?**
- No

**Other information**:
The `InjectionService` has singleton lifetime and it's quite dangerous to store any references it in. When we create a chart we put reference to its `ViewContainerRef`:

https://github.com/swimlane/ngx-charts/blob/c2257bbb2d0f96aef081e8749f639bb24198ec71/src/common/charts/chart.component.ts#L85-L89

When chart is later destroyed (e.g. due to navigation in app), it isn't reclaimed from the memory as `ViewContainerRef` is still rooted. The most upset fact is that `VCR` recursively stores references to the part contexts, so the whole component hierarchy stays alive.

----------

Notice, the fix I did is partial and formally nothing changed (I don't expect that `appRef.components` might disappear at run-time). Probably there is a fix for the cases when `ApplicationRef` is absent, but I don't know library enough to fix that.

@marjan-georgiev If possible, please drop a minor update of your library with this fix, as I spotted it profiling our app and we need a fix. Thanks for your review in advance. 🙏 🍷 