### PR TITLE
feat: reference lines can now be grouped bt adding a group property f…

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -751,6 +751,37 @@
         [referenceLines]="refLines"
         (select)="select($event)">
       </ngx-charts-line-chart>
+      <ngx-charts-line-chart
+        *ngIf="chartType === 'line-grouped-reference-lines'"
+        [view]="view"
+        class="chart-container"
+        [scheme]="colorScheme"
+        [schemeType]="schemeType"
+        [results]="multi"
+        [animations]="animations"
+        [legend]="showLegend"
+        [legendTitle]="legendTitle"
+        [legendPosition]="legendPosition"
+        (legendLabelClick)="onLegendLabelClick($event)"
+        [gradient]="gradient"
+        [xAxis]="showXAxis"
+        [yAxis]="showYAxis"
+        [showXAxisLabel]="showXAxisLabel"
+        [showYAxisLabel]="showYAxisLabel"
+        [xAxisLabel]="xAxisLabel"
+        [yAxisLabel]="yAxisLabel"
+        [autoScale]="autoScale"
+        [timeline]="timeline"
+        [showGridLines]="showGridLines"
+        [curve]="curve"
+        [rangeFillOpacity]="rangeFillOpacity"
+        [roundDomains]="roundDomains"
+        [tooltipDisabled]="tooltipDisabled"
+        [showRefLines]="showRefLines"
+        [showRefLabels]="showRefLabels"
+        [referenceLines]="refGroupedLines"
+        (select)="select($event)">
+      </ngx-charts-line-chart>
       <ngx-charts-bar-vertical
         *ngIf="chartType === 'tooltip-templates'"
         class="chart-container"

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -224,6 +224,13 @@ export class AppComponent implements OnInit {
   // Supports any number of reference lines.
   refLines = [{ value: 42500, name: 'Maximum' }, { value: 37750, name: 'Average' }, { value: 33000, name: 'Minimum' }];
 
+  refGroupedLines = [
+    { value: 40000, name: 'Abra', group: '1' }, 
+    { value: 36000, name: 'Kadabra', group: '1'  },
+    { value: 28000, name: 'Pokus', group: '2'  }, 
+    { value: 32000, name: 'Hokus', group: '2'  }
+  ];
+
   constructor(public location: Location) {
     this.mathFunction = this.getFunction();
 

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -694,6 +694,41 @@ const chartGroups = [
         }
       },
       {
+        name: 'Line Chart with grouped Reference Lines',
+        selector: 'line-grouped-reference-lines',
+        inputFormat: 'multiSeries',
+        options: [
+          'animations',
+          'colorScheme',
+          'schemeType',
+          'showXAxis',
+          'showYAxis',
+          'gradient',
+          'showLegend',
+          'legendTitle',
+          'legendPosition',
+          'showXAxisLabel',
+          'xAxisLabel',
+          'showYAxisLabel',
+          'yAxisLabel',
+          'autoScale',
+          'timeline',
+          'showGridLines',
+          'curve',
+          'rangeFillOpacity',
+          'roundDomains',
+          'tooltipDisabled',
+          'showRefLines',
+          'referenceLines',
+          'showRefLabels'
+        ],
+        defaults: {
+          yAxisLabel: 'GDP Per Capita',
+          xAxisLabel: 'Year',
+          linearScale: false
+        }
+      },
+      {
         name: 'Timeline Filter Bar Chart',
         selector: 'timeline-filter-bar-chart-demo',
         inputFormat: 'singleSeries',


### PR DESCRIPTION
**example:** 
Create groups of reference lines:
```
refGroupedLines = [
    { value: 40000, name: 'Abra', group: '1' }, 
    { value: 36000, name: 'Kadabra', group: '1'  },
    { value: 32000, name: 'Hokus', group: '2'  },
    { value: 28000, name: 'Pokus', group: '2'  }
  ];
```

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behaviour?**
Currently reference lines can only have one area (a grey area between min and max values)


**What is the new behavior?**
By adding an extra parameter (group) we can group lines into areas - this is to maintain backwards compatibility.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
