### PR TITLE
fix: pie chart label positioning for 7.x branch

### DIFF
--- a/src/pie-chart/pie-series.component.ts
+++ b/src/pie-chart/pie-series.component.ts
@@ -128,13 +128,18 @@ export class PieSeriesComponent implements OnChanges {
 
     for (let i = 0; i < labelPositions.length - 1; i++) {
       const a = labelPositions[i];
-
+      if (!this.labelVisible(a)) {
+        continue;
+      }
       for (let j = i + 1; j < labelPositions.length; j++) {
         const b = labelPositions[j];
         // if they're on the same side
         if (b.pos[0] * a.pos[0] > 0) {
           // if they're overlapping
           const o = minDistance - Math.abs(b.pos[1] - a.pos[1]);
+          if (!this.labelVisible(b)) {
+            continue;
+          }
           if (o > 0) {
             // push the second up or down
             b.pos[1] += Math.sign(b.pos[0]) * o;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Positioning of labels in Pie-charts sometimes places the labels outside of the container.
This has been reported in #844 


**What is the new behavior?**
The issue mentioned above has been fixed with version 8.0.2, see [here](https://github.com/swimlane/ngx-charts/commit/2568a4b7f36802d6bc98e42e31e0b90edac691e9).

But ngx-charts version 8.0 introduced a breaking change in depending on Angular 6!

This pull request introduces the necessary changes for the 7.x branch, so that users who have to continue working with Angluar 5 (and thus ngx-charts < 8) can also use correctly aligned labels.

Would be great if this could become ngx-charts v7.4.1


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I became aware of this problem while developing a Cordova application for Android/WebView.

With the changes applied, the display of labels in pie charts now works correctly.