### PR TITLE
Amounts on vertical stacked bar segments

### DIFF
--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -75,6 +75,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [tooltipDisabled]="tooltipDisabled"
             [tooltipTemplate]="tooltipTemplate"
             [showDataLabel]="showDataLabel"
+            [showSegmentLabels]="showSegmentLabels"
             [dataLabelFormatting]="dataLabelFormatting"
             [seriesName]="group.name"
             [animations]="animations"
@@ -130,6 +131,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() roundDomains: boolean = false;
   @Input() yScaleMax: number;
   @Input() showDataLabel: boolean = false;
+  @Input() showSegmentLabels: boolean = false;
   @Input() dataLabelFormatting: any;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();

--- a/src/bar-chart/bar.component.ts
+++ b/src/bar-chart/bar.component.ts
@@ -34,6 +34,14 @@ import { id } from '../utils/id';
       [attr.fill]="hasGradient ? gradientFill : fill"
       (click)="select.emit(data)"
     />
+    <svg:text *ngIf="showSegmentLabels"  
+      class="textDataLabel" 
+      alignment-baseline="middle"     
+      text-anchor="middle"
+      [attr.x]="x+width/2" 
+      [attr.y]="y+height/2">
+      {{value}}
+    </svg:text>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -53,6 +61,8 @@ export class BarComponent implements OnChanges {
   @Input() stops: any[];
   @Input() animations: boolean = true;
   @Input() ariaLabel: string;
+  @Input() value: string = "";
+  @Input() showSegmentLabels: boolean = false;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();

--- a/src/bar-chart/series-vertical.component.ts
+++ b/src/bar-chart/series-vertical.component.ts
@@ -24,7 +24,7 @@ export enum D0Types {
   selector: 'g[ngx-charts-series-vertical]',
   template: `
     <svg:g ngx-charts-bar
-      *ngFor="let bar of bars; trackBy: trackBy"
+      *ngFor="let bar of bars; trackBy: trackBy; let label of barsForDataLabels;"
       [@animationState]="'active'"
       [@.disabled]="!animations"
       [width]="bar.width"
@@ -49,13 +49,15 @@ export enum D0Types {
       [tooltipTitle]="tooltipTemplate ? undefined : bar.tooltipText"
       [tooltipTemplate]="tooltipTemplate"
       [tooltipContext]="bar.data"
-      [animations]="animations">
+      [animations]="animations"
+      [showSegmentLabels]="showSegmentLabels"
+      [value]="label.value">
     </svg:g>
     <svg:g *ngIf="showDataLabel">
       <svg:g ngx-charts-bar-label *ngFor="let b of barsForDataLabels; let i = index; trackBy:trackDataLabelBy"         
         [barX]="b.x"
         [barY]="b.y"
-        [barWidth]="b.width"
+        [barWidth]="b.width" 
         [barHeight]="b.height"
         [value]="b.total"
         [valueFormatting]="dataLabelFormatting"
@@ -92,6 +94,7 @@ export class SeriesVerticalComponent implements OnChanges {
   @Input() roundEdges: boolean;
   @Input() animations: boolean = true;
   @Input() showDataLabel: boolean = false;
+  @Input() showSegmentLabels: boolean = false;
   @Input() dataLabelFormatting: any;
 
   @Output() select = new EventEmitter();


### PR DESCRIPTION
Can set [showSegmentLabels]=true on stacked vertical bar charts to show amounts on each segment.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
stacked bars cannot have labels on each bar


**What is the new behavior?**
you can choose to put labels on each bar in a stacked bar chart


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No - lightly tested


**Other information**:
