### PR TITLE
Fix chart height with large number of yAxisTicks, just a Poc for further feedback to go or not

### DIFF
--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -189,14 +189,19 @@ export class BarVerticalComponent extends BaseChartComponent {
   getYDomain() {
     const values = this.results.map(d => d.value);
 
-    const min = this.yScaleMin
+    let min = this.yScaleMin
       ? Math.min(this.yScaleMin, ...values)
       : Math.min(0, ...values);
+    if (!this.yAxisTicks.some(isNaN)) {
+      min = Math.min(min, ...this.yAxisTicks);
+    }
 
-    const max = this.yScaleMax
+    let max = this.yScaleMax
       ? Math.max(this.yScaleMax, ...values)
       : Math.max(0, ...values);
-
+    if (!this.yAxisTicks.some(isNaN)) {
+      max = Math.max(min, ...this.yAxisTicks);
+    }
     return [min, max];
   }
 

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -192,15 +192,15 @@ export class BarVerticalComponent extends BaseChartComponent {
     let min = this.yScaleMin
       ? Math.min(this.yScaleMin, ...values)
       : Math.min(0, ...values);
-    if (!this.yAxisTicks.some(isNaN)) {
+    if (this.yAxisTicks && !this.yAxisTicks.some(isNaN)) {
       min = Math.min(min, ...this.yAxisTicks);
     }
 
     let max = this.yScaleMax
       ? Math.max(this.yScaleMax, ...values)
       : Math.max(0, ...values);
-    if (!this.yAxisTicks.some(isNaN)) {
-      max = Math.max(min, ...this.yAxisTicks);
+    if (this.yAxisTicks && !this.yAxisTicks.some(isNaN)) {
+      max = Math.max(max, ...this.yAxisTicks);
     }
     return [min, max];
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When specify `yAxisTicks`, if the max y tick is larger than the max yvalue of data and the `yScaleMax` data, then the inner `g` will exceed the height limit. The workaround is to set the `yScaleMax` larger equal then the largest value of `yAxisTicks`, but feel we should document somewhere.
In the meanwhile, open this POC PR to see if this fix is right on track and hope to got reviewed. The existing graph looks like (max height 300px):
![image](https://user-images.githubusercontent.com/3719246/52721649-1ec02280-2f78-11e9-90ee-117991c15154.png)


**What is the new behavior?**
Max height:300px
![image](https://user-images.githubusercontent.com/3719246/52721130-0b608780-2f77-11e9-9f64-ce70ecb4d8ab.png)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Not sure if other graphs are affected by this customized x and y ticks, but I highly doubt they all affected, because we just used the bar and line charts and already find they all kind of broken. Open this PR for POC purpose to make sure my understanding about this repo and fix is right on track. If got positive feedback from maintainer I will continue this PR to address other graphs.