### PR TITLE
User specified container element for Tooltip injection

### DIFF
--- a/demo/app.module.ts
+++ b/demo/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
-import { APP_BASE_HREF, Location } from '@angular/common';
+import { APP_BASE_HREF } from '@angular/common';
 import { AppComponent } from './app.component';
 import { SparklineComponent } from './sparkline/sparkline.component';
 import { TimelineFilterBarChartComponent } from './timeline-filter-bar-chart/timeline-filter-bar-chart.component';

--- a/src/common/tooltip/injection.service.ts
+++ b/src/common/tooltip/injection.service.ts
@@ -32,6 +32,7 @@ export class InjectionService {
   }
 
   private _container: ComponentRef<any>;
+  private _containerElement: HTMLElement;
 
   constructor(
     private applicationRef: ApplicationRef,
@@ -73,6 +74,17 @@ export class InjectionService {
   }
 
   /**
+   * Defines the container element.
+   *
+   * @param {HTMLElement} container
+   *
+   * @memberOf InjectionService
+   */
+  setContainerElement(container: HTMLElement): void {
+    this._containerElement = container;
+  }
+
+  /**
    * Gets the html element for a component ref.
    *
    * @param {ComponentRef<any>} componentRef
@@ -96,6 +108,21 @@ export class InjectionService {
    */
   getRootViewContainerNode(): HTMLElement {
     return this.getComponentRootNode(this.getRootViewContainer());
+  }
+
+  /**
+   * Gets the container html element.
+   *
+   * @returns {HTMLElement}
+   *
+   * @memberOf InjectionService
+   */
+  getContainerElement(): HTMLElement {
+    // user defined container element
+    if (this._containerElement) return this._containerElement;
+
+    // root view container
+    return this.getRootViewContainerNode();
   }
 
   /**
@@ -133,7 +160,7 @@ export class InjectionService {
    * @template T
    * @param {Type<T>} componentClass
    * @param {*} [options={}]
-   * @param {Element} [location=this.getRootViewContainerNode()]
+   * @param {Element} [location=this.getContainerElement()]
    * @returns {ComponentRef<any>}
    *
    * @memberOf InjectionService
@@ -141,7 +168,7 @@ export class InjectionService {
   appendComponent<T>(
     componentClass: Type<T>,
     bindings: any = {},
-    location: Element = this.getRootViewContainerNode()
+    location: Element = this.getContainerElement()
   ): ComponentRef<any> {
     const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentClass);
     const componentRef: any = componentFactory.create(this.injector);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Tooltips are currently injected in the app root which prevents the active tooltip from being visible when a child element enters [Fullscreen](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).   Any parent element of a fullscreen element is hidden per the specification.


**What is the new behavior?**
This PR simply adds an **optional** variable which allows a user to specify what the container element should be injected into vs being automatically injected into the app root.  If left unspecified, the app root is used as was previously.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Example usage:

*app.component.ts*:

```javascript
this.injectionService.setContainerElement(this.chartContainer.nativeElement)
```