### PR TITLE
Changed tree-map label class to avoid conflict

### DIFF
--- a/src/tree-map/tree-map-cell.component.ts
+++ b/src/tree-map/tree-map-cell.component.ts
@@ -32,7 +32,7 @@ import { id } from '../utils/id';
         [attr.y]="y"
         [attr.width]="width"
         [attr.height]="height"
-        class="label"
+        class="treemap-label"
         [style.pointer-events]="'none'">
         <xhtml:p
           [style.color]="getTextColor()"

--- a/src/tree-map/tree-map.component.scss
+++ b/src/tree-map/tree-map.component.scss
@@ -5,7 +5,7 @@
     display: inline-block;
   }
 
-  .label p {
+  .treemap-label p {
     display: table-cell;
     text-align: center;
     line-height: 1.2em;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

foreignObject uses the label class that can conflict with other libraries.

```
<foreignObject class="label ng-star-inserted" x="0" y="0" width="364.15491003825497" height="151" style="pointer-events: none;"><p style="color: rgb(216, 226, 235); height: 151px; width: 364.155px;"><span class="treemap-label">Google</span><br><!----><span class="treemap-val ng-star-inserted" ngx-charts-count-up="">10.2 TB</span><!----></p></foreignObject>
```


**What is the new behavior?**

changed the label class to treemap-label to avoid conflicts.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
