### PR TITLE
Remove unused property binding from demo chart

### DIFF
--- a/demo/combo-chart/combo-chart.component.ts
+++ b/demo/combo-chart/combo-chart.component.ts
@@ -90,7 +90,7 @@ import { scaleBand, scaleLinear, scalePoint, scaleTime } from 'd3-scale';
         </svg:g>
       </svg:g>
       <svg:g [attr.transform]="transform" class="line-chart chart">
-        <svg:g [attr.clip-path]="clipPath">
+        <svg:g>
           <svg:g *ngFor="let series of lineChart; trackBy:trackBy">
             <svg:g ngx-charts-line-series
               [xScale]="xScaleLine"


### PR DESCRIPTION
The clip-path binding is not used in this component, there is no matching property in the typescript

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The demo Combo Chart component contains an unused property binding.


**What is the new behavior?**
The unused binding has been removed.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
