### PR TITLE
Update tooltip positioning to correctly flip sides when there is not enough available space

### DIFF
--- a/src/common/tooltip/position/position.spec.ts
+++ b/src/common/tooltip/position/position.spec.ts
@@ -1,0 +1,176 @@
+import { PositionHelper } from './position';
+
+describe('positioning', () => {
+
+    describe('flip', () => {
+
+        describe('top', () => {
+            it('keep', () => {
+                (window as any).innerWidth = 500;
+                (window as any).innerHeight = 500;
+
+                const elementDimensions = {
+                    top: 50,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 'center', 0);
+                expect(shouldFlip).toEqual(false);
+            });
+
+            it('flip', () => {
+                (window as any).innerWidth = 500;
+                (window as any).innerHeight = 500;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 'center', 0);
+                expect(shouldFlip).toEqual(true);
+            });
+        });
+
+        describe('bottom', () => {
+            it('keep', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 'center', 0);
+                expect(shouldFlip).toEqual(false);
+            });
+
+            it('flip', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 100,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 'center', 0);
+                expect(shouldFlip).toEqual(true);
+            });
+        });
+
+        describe('left', () => {
+            it('keep', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 'center', 0);
+                expect(shouldFlip).toEqual(false);
+            });
+
+            it('flip', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 0,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 'center', 0);
+                expect(shouldFlip).toEqual(true);
+            });
+        });
+        
+        describe('right', () => {
+            it('keep', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 0,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 'center', 0);
+                expect(shouldFlip).toEqual(false);
+            });
+
+            it('flip', () => {
+                (window as any).innerWidth = 200;
+                (window as any).innerHeight = 200;
+
+                const elementDimensions = {
+                    top: 0,
+                    left: 100,
+                    width: 100,
+                    height: 100
+                };
+
+                const popoverDimensions = {
+                    width: 100,
+                    height: 50
+                };
+
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 'center', 0);
+                expect(shouldFlip).toEqual(true);
+            });
+        });
+
+    });
+});

--- a/src/common/tooltip/position/position.spec.ts
+++ b/src/common/tooltip/position/position.spec.ts
@@ -21,7 +21,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 0);
                 expect(shouldFlip).toEqual(false);
             });
 
@@ -41,7 +41,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'top', 0);
                 expect(shouldFlip).toEqual(true);
             });
         });
@@ -63,7 +63,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 0);
                 expect(shouldFlip).toEqual(false);
             });
 
@@ -83,7 +83,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'bottom', 0);
                 expect(shouldFlip).toEqual(true);
             });
         });
@@ -105,7 +105,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 0);
                 expect(shouldFlip).toEqual(false);
             });
 
@@ -125,7 +125,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'left', 0);
                 expect(shouldFlip).toEqual(true);
             });
         });
@@ -147,7 +147,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 0);
                 expect(shouldFlip).toEqual(false);
             });
 
@@ -167,7 +167,7 @@ describe('positioning', () => {
                     height: 50
                 };
 
-                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 'center', 0);
+                const shouldFlip = PositionHelper.shouldFlip(elementDimensions, popoverDimensions, 'right', 0);
                 expect(shouldFlip).toEqual(true);
             });
         });

--- a/src/common/tooltip/position/position.ts
+++ b/src/common/tooltip/position/position.ts
@@ -161,25 +161,22 @@ export class PositionHelper {
    * @param {any} elDimensions
    * @param {any} popoverDimensions
    * @param {any} placement
-   * @param {any} alignment
    * @param {any} spacing
    * @returns {boolean}
    * 
    * @memberOf PositionHelper
    */
-  static shouldFlip(elDimensions, popoverDimensions, placement, alignment, spacing): boolean {
+  static shouldFlip(elDimensions, popoverDimensions, placement, spacing): boolean {
     let flip = false;
 
     if (placement === 'right') {
-      const popoverPosition = horizontalPosition(elDimensions, popoverDimensions, alignment);
-      if (popoverPosition + popoverDimensions.width + spacing > window.innerWidth) {
+      if (elDimensions.left + elDimensions.width + popoverDimensions.width + spacing > window.innerWidth) {
         flip = true;
       }
     }
 
     if (placement === 'left') {
-      const popoverPosition = horizontalPosition(elDimensions, popoverDimensions, alignment);
-      if (popoverPosition - spacing < 0) {
+      if (elDimensions.left - popoverDimensions.width - spacing < 0) {
         flip = true;
       }
     }
@@ -191,8 +188,7 @@ export class PositionHelper {
     }
 
     if (placement === 'bottom') {
-      const popoverPosition = verticalPosition(elDimensions, popoverDimensions, alignment);
-      if (popoverPosition + popoverDimensions.height + spacing > window.innerHeight) {
+      if (elDimensions.top + elDimensions.height + popoverDimensions.height + spacing > window.innerHeight) {
         flip = true;
       }
     }
@@ -284,17 +280,15 @@ export class PositionHelper {
    * @param {any} elmDim
    * @param {any} hostDim
    * @param {any} spacing
-   * @param {any} alignment
    * @returns {*}
    * 
    * @memberOf PositionHelper
    */
-  static determinePlacement(placement, elmDim, hostDim, spacing, alignment): any {
+  static determinePlacement(placement, elmDim, hostDim, spacing): any {
     const shouldFlip = PositionHelper.shouldFlip(
       hostDim,
       elmDim,
       placement,
-      alignment,
       spacing);
 
     if(shouldFlip) {

--- a/src/common/tooltip/tooltip.component.ts
+++ b/src/common/tooltip/tooltip.component.ts
@@ -107,7 +107,7 @@ export class TooltipContentComponent implements AfterViewInit {
 
   checkFlip(hostDim, elmDim): void {
     this.placement = PositionHelper.determinePlacement(
-      this.placement, elmDim, hostDim, this.spacing, this.alignment);
+      this.placement, elmDim, hostDim, this.spacing);
   }
 
   @HostListener('window:resize')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
[Open Issue](https://github.com/swimlane/ngx-charts/issues/1081)
The issue can also be observed on the [demo page line chart](https://swimlane.github.io/ngx-charts/#/ngx-charts/line-chart) by setting your browser width to 788px and observing the final two series tooltips


**What is the new behavior?**
The positioning check is now independent of alignment and will correctly determine if there is enough available space.


**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No
I wasn't sure how to mark this, but I chose "Yes" because I removed an input parameter. If someone were importing the PositionHelper directly, this would break for them.

If this PR contains a breaking change, please describe the impact and migration path for existing applications:
Assuming the above situation, the impact would be a build failure that will be easily detected and diagnosed.
These methods shouldn't be using the alignment at all, so the migration path is to just remove that parameter from the method call.


**Other information**:
My understanding of placement vs alignment for this change: "placement" is which side of the parent object the tooltip should display (top, bottom, left, right), and "alignment" is where on that side the tooltip should anchor (top, center, bottom for left/right placement and left, center, right, for top/bottom placement).
Assuming that is correct, then this change is correct because "shouldFlip" is trying to determine if there is enough space using a specific placement - which is alignment independent, IE the space required for "right-center" is the same as "right-top" and "right-bottom".