### PR TITLE
Replace bitwise operator ~~ with math.floor

### DIFF
--- a/src/common/base-chart.component.ts
+++ b/src/common/base-chart.component.ts
@@ -81,8 +81,8 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
       this.height = 400;
     }
 
-    this.width = ~~this.width;
-    this.height = ~~this.height;
+    this.width = Math.floor(this.width);
+    this.height = Math.floor(this.height);
 
     if (this.cd) {
       this.cd.markForCheck();

--- a/src/common/charts/chart.component.ts
+++ b/src/common/charts/chart.component.ts
@@ -108,9 +108,9 @@ export class ChartComponent implements OnChanges {
 
     const chartColumns = 12 - legendColumns;
 
-    this.chartWidth = ~~(this.view[0] * chartColumns / 12.0);
+    this.chartWidth = Math.floor((this.view[0] * chartColumns / 12.0));
     this.legendWidth = (!this.legendOptions || this.legendOptions.position === 'right')
-      ? ~~(this.view[0] * legendColumns / 12.0)
+      ? Math.floor((this.view[0] * legendColumns / 12.0))
       : this.chartWidth;
   }
 

--- a/src/common/view-dimensions.helper.ts
+++ b/src/common/view-dimensions.helper.ts
@@ -54,8 +54,8 @@ export function calculateViewDimensions({
   chartHeight = Math.max(0, chartHeight);
 
   return {
-    width: ~~chartWidth,
-    height: ~~chartHeight,
-    xOffset: ~~xOffset
+    width: Math.floor(chartWidth),
+    height: Math.floor(chartHeight),
+    xOffset: Math.floor(xOffset)
   };
 }

--- a/src/polar-chart/polar-chart.component.ts
+++ b/src/polar-chart/polar-chart.component.ts
@@ -212,8 +212,8 @@ export class PolarChartComponent extends BaseChartComponent {
       legendPosition: this.legendPosition
     });
 
-    const halfWidth = ~~(this.dims.width / 2);
-    const halfHeight = ~~(this.dims.height / 2);
+    const halfWidth = Math.floor((this.dims.width / 2));
+    const halfHeight = Math.floor((this.dims.height / 2));
 
     const outerRadius = this.outerRadius = Math.min(halfHeight / 1.5, halfWidth / 1.5);
 
@@ -301,7 +301,7 @@ export class PolarChartComponent extends BaseChartComponent {
     }
 
     this.radiusTicks = this.yAxisScale
-      .ticks(~~(this.dims.height / 50))
+      .ticks(Math.floor((this.dims.height / 50)))
       .map(d => this.yScale(d));
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
There is an inconsistent use of using bitwise operators (~~) and Math.floor() to round numbers down.


**What is the new behavior?**
A consistent usage of Math.floor() rather than ~~.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:  
While in some browsers using ~~ to floor a variable can be faster than Math.floor() it isn't consistently faster between browsers or even browser versions. As Math.floor() is more readable it seems preferable. 

