### PR TITLE
Combo Line and Bar chart not aligning

### DIFF
--- a/demo/combo-chart/combo-chart.component.ts
+++ b/demo/combo-chart/combo-chart.component.ts
@@ -419,7 +419,7 @@ export class ComboChartComponent extends BaseChartComponent  {
     this.xDomain = this.getXDomain();
     const spacing = this.xDomain.length / (this.dims.width / this.barPadding + 1);
     return scaleBand()
-      .rangeRound([0, this.dims.width])
+      .range([0, this.dims.width])
       .paddingInner(spacing)
       .domain(this.xDomain);
   }

--- a/src/bar-chart/bar-vertical.component.ts
+++ b/src/bar-chart/bar-vertical.component.ts
@@ -169,7 +169,7 @@ export class BarVerticalComponent extends BaseChartComponent {
     this.xDomain = this.getXDomain();
     const spacing = this.xDomain.length / (this.dims.width / this.barPadding + 1);
     return scaleBand()
-      .rangeRound([0, this.dims.width])
+      .range([0, this.dims.width])
       .paddingInner(spacing)
       .domain(this.xDomain);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
As mentioned in the issue: https://github.com/swimlane/ngx-charts/issues/728
If we have many variables (more than 50) in the `results`  of `bar-chart` or `combo-chart`, there will be too much spacing around the left and right of the `bar-chart`, resulting the line and bar not aligning in the `combo-chart`.
set the `results` of `bar-chart` or `combo-chart` to be (180 variables)
```
[{ time: 1556612978, name: '16:29:38', value: 180 }, { time: 1556613018, name: '16:30:18', value: 145 }, { time: 1556613058, name: '16:30:58', value: 144 }, { time: 1556613098, name: '16:31:38', value: 144 }, { time: 1556613138, name: '16:32:18', value: 144 }, { time: 1556613178, name: '16:32:58', value: 144 }, { time: 1556613218, name: '16:33:38', value: 144 }, { time: 1556613258, name: '16:34:18', value: 144 }, { time: 1556613298, name: '16:34:58', value: 144 }, { time: 1556613338, name: '16:35:38', value: 144 }, { time: 1556613378, name: '16:36:18', value: 144 }, { time: 1556613418, name: '16:36:58', value: 144 }, { time: 1556613458, name: '16:37:38', value: 144 }, { time: 1556613498, name: '16:38:18', value: 144 }, { time: 1556613538, name: '16:38:58', value: 144 }, { time: 1556613578, name: '16:39:38', value: 144 }, { time: 1556613618, name: '16:40:18', value: 144 }, { time: 1556613658, name: '16:40:58', value: 144 }, { time: 1556613698, name: '16:41:38', value: 144 }, { time: 1556613738, name: '16:42:18', value: 144 }, { time: 1556613778, name: '16:42:58', value: 144 }, { time: 1556613818, name: '16:43:38', value: 144 }, { time: 1556613858, name: '16:44:18', value: 144 }, { time: 1556613898, name: '16:44:58', value: 144 }, { time: 1556613938, name: '16:45:38', value: 144 }, { time: 1556613978, name: '16:46:18', value: 144 }, { time: 1556614018, name: '16:46:58', value: 144 }, { time: 1556614058, name: '16:47:38', value: 144 }, { time: 1556614098, name: '16:48:18', value: 144 }, { time: 1556614138, name: '16:48:58', value: 144 }, { time: 1556614178, name: '16:49:38', value: 144 }, { time: 1556614218, name: '16:50:18', value: 144 }, { time: 1556614258, name: '16:50:58', value: 144 }, { time: 1556614298, name: '16:51:38', value: 144 }, { time: 1556614338, name: '16:52:18', value: 144 }, { time: 1556614378, name: '16:52:58', value: 144 }, { time: 1556614418, name: '16:53:38', value: 144 }, { time: 1556614458, name: '16:54:18', value: 144 }, { time: 1556614498, name: '16:54:58', value: 144 }, { time: 1556614538, name: '16:55:38', value: 144 }, { time: 1556614578, name: '16:56:18', value: 144 }, { time: 1556614618, name: '16:56:58', value: 144 }, { time: 1556614658, name: '16:57:38', value: 144 }, { time: 1556614698, name: '16:58:18', value: 144 }, { time: 1556614738, name: '16:58:58', value: 144 }, { time: 1556614778, name: '16:59:38', value: 144 }, { time: 1556614818, name: '17:00:18', value: 144 }, { time: 1556614858, name: '17:00:58', value: 144 }, { time: 1556614898, name: '17:01:38', value: 144 }, { time: 1556614938, name: '17:02:18', value: 144 }, { time: 1556614978, name: '17:02:58', value: 144 }, { time: 1556615018, name: '17:03:38', value: 144 }, { time: 1556615058, name: '17:04:18', value: 144 }, { time: 1556615098, name: '17:04:58', value: 144 }, { time: 1556615138, name: '17:05:38', value: 144 }, { time: 1556615178, name: '17:06:18', value: 144 }, { time: 1556615218, name: '17:06:58', value: 144 }, { time: 1556615258, name: '17:07:38', value: 144 }, { time: 1556615298, name: '17:08:18', value: 144 }, { time: 1556615338, name: '17:08:58', value: 144 }, { time: 1556615378, name: '17:09:38', value: 144 }, { time: 1556615418, name: '17:10:18', value: 144 }, { time: 1556615458, name: '17:10:58', value: 144 }, { time: 1556615498, name: '17:11:38', value: 144 }, { time: 1556615538, name: '17:12:18', value: 144 }, { time: 1556615578, name: '17:12:58', value: 144 }, { time: 1556615618, name: '17:13:38', value: 144 }, { time: 1556615658, name: '17:14:18', value: 144 }, { time: 1556615698, name: '17:14:58', value: 144 }, { time: 1556615738, name: '17:15:38', value: 144 }, { time: 1556615778, name: '17:16:18', value: 144 }, { time: 1556615818, name: '17:16:58', value: 144 }, { time: 1556615858, name: '17:17:38', value: 144 }, { time: 1556615898, name: '17:18:18', value: 144 }, { time: 1556615938, name: '17:18:58', value: 144 }, { time: 1556615978, name: '17:19:38', value: 144 }, { time: 1556616018, name: '17:20:18', value: 144 }, { time: 1556616058, name: '17:20:58', value: 144 }, { time: 1556616098, name: '17:21:38', value: 144 }, { time: 1556616138, name: '17:22:18', value: 144 }, { time: 1556616178, name: '17:22:58', value: 144 }, { time: 1556616218, name: '17:23:38', value: 144 }, { time: 1556616258, name: '17:24:18', value: 144 }, { time: 1556616298, name: '17:24:58', value: 144 }, { time: 1556616338, name: '17:25:38', value: 144 }, { time: 1556616378, name: '17:26:18', value: 144 }, { time: 1556616418, name: '17:26:58', value: 144 }, { time: 1556616458, name: '17:27:38', value: 144 }, { time: 1556616498, name: '17:28:18', value: 144 }, { time: 1556616538, name: '17:28:58', value: 144 }, { time: 1556616578, name: '17:29:38', value: 144 }, { time: 1556616618, name: '17:30:18', value: 144 }, { time: 1556616658, name: '17:30:58', value: 144 }, { time: 1556616698, name: '17:31:38', value: 144 }, { time: 1556616738, name: '17:32:18', value: 144 }, { time: 1556616778, name: '17:32:58', value: 144 }, { time: 1556616818, name: '17:33:38', value: 144 }, { time: 1556616858, name: '17:34:18', value: 144 }, { time: 1556616898, name: '17:34:58', value: 144 }, { time: 1556616938, name: '17:35:38', value: 144 }, { time: 1556616978, name: '17:36:18', value: 144 }, { time: 1556617018, name: '17:36:58', value: 144 }, { time: 1556617058, name: '17:37:38', value: 144 }, { time: 1556617098, name: '17:38:18', value: 144 }, { time: 1556617138, name: '17:38:58', value: 146 }, { time: 1556617178, name: '17:39:38', value: 146 }, { time: 1556617218, name: '17:40:18', value: 146 }, { time: 1556617258, name: '17:40:58', value: 144 }, { time: 1556617298, name: '17:41:38', value: 144 }, { time: 1556617338, name: '17:42:18', value: 144 }, { time: 1556617378, name: '17:42:58', value: 144 }, { time: 1556617418, name: '17:43:38', value: 144 }, { time: 1556617458, name: '17:44:18', value: 144 }, { time: 1556617498, name: '17:44:58', value: 144 }, { time: 1556617538, name: '17:45:38', value: 144 }, { time: 1556617578, name: '17:46:18', value: 144 }, { time: 1556617618, name: '17:46:58', value: 144 }, { time: 1556617658, name: '17:47:38', value: 144 }, { time: 1556617698, name: '17:48:18', value: 144 }, { time: 1556617738, name: '17:48:58', value: 144 }, { time: 1556617778, name: '17:49:38', value: 144 }, { time: 1556617818, name: '17:50:18', value: 144 }, { time: 1556617858, name: '17:50:58', value: 144 }, { time: 1556617898, name: '17:51:38', value: 144 }, { time: 1556617938, name: '17:52:18', value: 144 }, { time: 1556617978, name: '17:52:58', value: 144 }, { time: 1556618018, name: '17:53:38', value: 144 }, { time: 1556618058, name: '17:54:18', value: 144 }, { time: 1556618098, name: '17:54:58', value: 144 }, { time: 1556618138, name: '17:55:38', value: 144 }, { time: 1556618178, name: '17:56:18', value: 144 }, { time: 1556618218, name: '17:56:58', value: 144 }, { time: 1556618258, name: '17:57:38', value: 144 }, { time: 1556618298, name: '17:58:18', value: 144 }, { time: 1556618338, name: '17:58:58', value: 144 }, { time: 1556618378, name: '17:59:38', value: 144 }, { time: 1556618418, name: '18:00:18', value: 144 }, { time: 1556618458, name: '18:00:58', value: 144 }, { time: 1556618498, name: '18:01:38', value: 144 }, { time: 1556618538, name: '18:02:18', value: 144 }, { time: 1556618578, name: '18:02:58', value: 144 }, { time: 1556618618, name: '18:03:38', value: 144 }, { time: 1556618658, name: '18:04:18', value: 144 }, { time: 1556618698, name: '18:04:58', value: 144 }, { time: 1556618738, name: '18:05:38', value: 144 }, { time: 1556618778, name: '18:06:18', value: 144 }, { time: 1556618818, name: '18:06:58', value: 144 }, { time: 1556618858, name: '18:07:38', value: 144 }, { time: 1556618898, name: '18:08:18', value: 144 }, { time: 1556618938, name: '18:08:58', value: 144 }, { time: 1556618978, name: '18:09:38', value: 144 }, { time: 1556619018, name: '18:10:18', value: 144 }, { time: 1556619058, name: '18:10:58', value: 144 }, { time: 1556619098, name: '18:11:38', value: 144 }, { time: 1556619138, name: '18:12:18', value: 144 }, { time: 1556619178, name: '18:12:58', value: 144 }, { time: 1556619218, name: '18:13:38', value: 144 }, { time: 1556619258, name: '18:14:18', value: 144 }, { time: 1556619298, name: '18:14:58', value: 144 }, { time: 1556619338, name: '18:15:38', value: 144 }, { time: 1556619378, name: '18:16:18', value: 144 }, { time: 1556619418, name: '18:16:58', value: 144 }, { time: 1556619458, name: '18:17:38', value: 144 }, { time: 1556619498, name: '18:18:18', value: 144 }, { time: 1556619538, name: '18:18:58', value: 144 }, { time: 1556619578, name: '18:19:38', value: 144 }, { time: 1556619618, name: '18:20:18', value: 144 }, { time: 1556619658, name: '18:20:58', value: 144 }, { time: 1556619698, name: '18:21:38', value: 144 }, { time: 1556619738, name: '18:22:18', value: 145 }, { time: 1556619778, name: '18:22:58', value: 144 }, { time: 1556619818, name: '18:23:38', value: 145 }, { time: 1556619858, name: '18:24:18', value: 144 }, { time: 1556619898, name: '18:24:58', value: 144 }, { time: 1556619938, name: '18:25:38', value: 144 }, { time: 1556619978, name: '18:26:18', value: 144 }, { time: 1556620018, name: '18:26:58', value: 144 }, { time: 1556620058, name: '18:27:38', value: 144 }, { time: 1556620098, name: '18:28:18', value: 144 }, { time: 1556620138, name: '18:28:58', value: 200 }]
```
set the `lineChart` of `combo-chart` to be (180 variables)
```
[
  {
    name: 'Tablets',
    series: [{ name: '16:29:38', value: 10 }, { name: '16:30:18', value: 10 }, { name: '16:30:58', value: 10 }, { name: '16:31:38', value: 10 }, { name: '16:32:18', value: 10 }, { name: '16:32:58', value: 10 }, { name: '16:33:38', value: 10 }, { name: '16:34:18', value: 10 }, { name: '16:34:58', value: 10 }, { name: '16:35:38', value: 10 }, { name: '16:36:18', value: 10 }, { name: '16:36:58', value: 10 }, { name: '16:37:38', value: 10 }, { name: '16:38:18', value: 10 }, { name: '16:38:58', value: 10 }, { name: '16:39:38', value: 10 }, { name: '16:40:18', value: 10 }, { name: '16:40:58', value: 10 }, { name: '16:41:38', value: 10 }, { name: '16:42:18', value: 10 }, { name: '16:42:58', value: 10 }, { name: '16:43:38', value: 10 }, { name: '16:44:18', value: 10 }, { name: '16:44:58', value: 10 }, { name: '16:45:38', value: 10 }, { name: '16:46:18', value: 10 }, { name: '16:46:58', value: 10 }, { name: '16:47:38', value: 10 }, { name: '16:48:18', value: 10 }, { name: '16:48:58', value: 10 }, { name: '16:49:38', value: 10 }, { name: '16:50:18', value: 10 }, { name: '16:50:58', value: 10 }, { name: '16:51:38', value: 10 }, { name: '16:52:18', value: 10 }, { name: '16:52:58', value: 10 }, { name: '16:53:38', value: 10 }, { name: '16:54:18', value: 10 }, { name: '16:54:58', value: 10 }, { name: '16:55:38', value: 10 }, { name: '16:56:18', value: 10 }, { name: '16:56:58', value: 10 }, { name: '16:57:38', value: 10 }, { name: '16:58:18', value: 10 }, { name: '16:58:58', value: 10 }, { name: '16:59:38', value: 10 }, { name: '17:00:18', value: 10 }, { name: '17:00:58', value: 10 }, { name: '17:01:38', value: 10 }, { name: '17:02:18', value: 10 }, { name: '17:02:58', value: 10 }, { name: '17:03:38', value: 10 }, { name: '17:04:18', value: 10 }, { name: '17:04:58', value: 10 }, { name: '17:05:38', value: 10 }, { name: '17:06:18', value: 10 }, { name: '17:06:58', value: 10 }, { name: '17:07:38', value: 10 }, { name: '17:08:18', value: 10 }, { name: '17:08:58', value: 10 }, { name: '17:09:38', value: 10 }, { name: '17:10:18', value: 10 }, { name: '17:10:58', value: 10 }, { name: '17:11:38', value: 10 }, { name: '17:12:18', value: 10 }, { name: '17:12:58', value: 10 }, { name: '17:13:38', value: 10 }, { name: '17:14:18', value: 10 }, { name: '17:14:58', value: 10 }, { name: '17:15:38', value: 10 }, { name: '17:16:18', value: 10 }, { name: '17:16:58', value: 10 }, { name: '17:17:38', value: 10 }, { name: '17:18:18', value: 10 }, { name: '17:18:58', value: 10 }, { name: '17:19:38', value: 10 }, { name: '17:20:18', value: 10 }, { name: '17:20:58', value: 10 }, { name: '17:21:38', value: 10 }, { name: '17:22:18', value: 10 }, { name: '17:22:58', value: 10 }, { name: '17:23:38', value: 10 }, { name: '17:24:18', value: 10 }, { name: '17:24:58', value: 10 }, { name: '17:25:38', value: 10 }, { name: '17:26:18', value: 10 }, { name: '17:26:58', value: 10 }, { name: '17:27:38', value: 10 }, { name: '17:28:18', value: 10 }, { name: '17:28:58', value: 10 }, { name: '17:29:38', value: 10 }, { name: '17:30:18', value: 10 }, { name: '17:30:58', value: 10 }, { name: '17:31:38', value: 10 }, { name: '17:32:18', value: 10 }, { name: '17:32:58', value: 10 }, { name: '17:33:38', value: 10 }, { name: '17:34:18', value: 10 }, { name: '17:34:58', value: 10 }, { name: '17:35:38', value: 10 }, { name: '17:36:18', value: 10 }, { name: '17:36:58', value: 10 }, { name: '17:37:38', value: 10 }, { name: '17:38:18', value: 10 }, { name: '17:38:58', value: 10 }, { name: '17:39:38', value: 10 }, { name: '17:40:18', value: 10 }, { name: '17:40:58', value: 10 }, { name: '17:41:38', value: 10 }, { name: '17:42:18', value: 10 }, { name: '17:42:58', value: 10 }, { name: '17:43:38', value: 10 }, { name: '17:44:18', value: 10 }, { name: '17:44:58', value: 10 }, { name: '17:45:38', value: 10 }, { name: '17:46:18', value: 10 }, { name: '17:46:58', value: 10 }, { name: '17:47:38', value: 10 }, { name: '17:48:18', value: 10 }, { name: '17:48:58', value: 10 }, { name: '17:49:38', value: 10 }, { name: '17:50:18', value: 10 }, { name: '17:50:58', value: 10 }, { name: '17:51:38', value: 10 }, { name: '17:52:18', value: 10 }, { name: '17:52:58', value: 10 }, { name: '17:53:38', value: 10 }, { name: '17:54:18', value: 10 }, { name: '17:54:58', value: 10 }, { name: '17:55:38', value: 10 }, { name: '17:56:18', value: 10 }, { name: '17:56:58', value: 10 }, { name: '17:57:38', value: 10 }, { name: '17:58:18', value: 10 }, { name: '17:58:58', value: 10 }, { name: '17:59:38', value: 10 }, { name: '18:00:18', value: 10 }, { name: '18:00:58', value: 10 }, { name: '18:01:38', value: 10 }, { name: '18:02:18', value: 10 }, { name: '18:02:58', value: 10 }, { name: '18:03:38', value: 10 }, { name: '18:04:18', value: 10 }, { name: '18:04:58', value: 10 }, { name: '18:05:38', value: 10 }, { name: '18:06:18', value: 10 }, { name: '18:06:58', value: 10 }, { name: '18:07:38', value: 10 }, { name: '18:08:18', value: 10 }, { name: '18:08:58', value: 10 }, { name: '18:09:38', value: 10 }, { name: '18:10:18', value: 10 }, { name: '18:10:58', value: 10 }, { name: '18:11:38', value: 10 }, { name: '18:12:18', value: 10 }, { name: '18:12:58', value: 10 }, { name: '18:13:38', value: 10 }, { name: '18:14:18', value: 10 }, { name: '18:14:58', value: 10 }, { name: '18:15:38', value: 10 }, { name: '18:16:18', value: 10 }, { name: '18:16:58', value: 10 }, { name: '18:17:38', value: 10 }, { name: '18:18:18', value: 10 }, { name: '18:18:58', value: 10 }, { name: '18:19:38', value: 10 }, { name: '18:20:18', value: 10 }, { name: '18:20:58', value: 10 }, { name: '18:21:38', value: 10 }, { name: '18:22:18', value: 10 }, { name: '18:22:58', value: 10 }, { name: '18:23:38', value: 10 }, { name: '18:24:18', value: 10 }, { name: '18:24:58', value: 10 }, { name: '18:25:38', value: 10 }, { name: '18:26:18', value: 10 }, { name: '18:26:58', value: 10 }, { name: '18:27:38', value: 10 }, { name: '18:28:18', value: 10 }, { name: '18:28:58', value: 10 }]
  }
]
```
we can see there are too much spacing around the left and right of the `bar-chart`:
<img width="737" alt="WX20190504-155401@2x" src="https://user-images.githubusercontent.com/42362436/57176057-c2d5ad80-6e85-11e9-95b9-f4ba72cc4f31.png">

we can see there are too much spacing around the left and right of the `bar-chart`, resulting the line and bar not aligning in the `combo-chart`:
<img width="756" alt="WX20190504-155553@2x" src="https://user-images.githubusercontent.com/42362436/57176043-ac2f5680-6e85-11e9-8e6d-710ec36b6cc5.png">


**What is the new behavior?**
new `bar-chart`:
<img width="725" alt="WX20190504-154818@2x" src="https://user-images.githubusercontent.com/42362436/57176083-fd3f4a80-6e85-11e9-8b66-bcb85fcbf22b.png">
new `combo-chart`:
<img width="765" alt="WX20190504-154842@2x" src="https://user-images.githubusercontent.com/42362436/57176081-fd3f4a80-6e85-11e9-8017-68c0d6b60d76.png">

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
