### PR TITLE
Deprecate force-directed graph chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more info, check out the [documentation](https://swimlane.gitbook.io/ngx-cha
 - Bubble
 - Donut
 - Gauge (Linear & Radial)
-- Force Directed Graph (deprecated - please use [ngx-graph](https://github.com/swimlane/ngx-graph) instead)
+- Force Directed Graph (deprecated, please use [ngx-graph](https://github.com/swimlane/ngx-graph) instead)
 - Heatmap
 - Treemap
 - Number Cards

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # ngx-charts
-[![Join the chat at https://gitter.im/swimlane/ngx-charts](https://badges.gitter.im/swimlane/ngx-charts.svg)](https://gitter.im/swimlane/ngx-charts?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
-[![Build Status](https://travis-ci.org/swimlane/ngx-charts.svg?branch=master)](https://travis-ci.org/swimlane/ngx-charts) 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b097196f7f544412a79a99080a41bbc1)](https://www.codacy.com/app/Swimlane/ngx-charts?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=swimlane/ngx-charts&amp;utm_campaign=Badge_Grade)
+
+[![Join the chat at https://gitter.im/swimlane/ngx-charts](https://badges.gitter.im/swimlane/ngx-charts.svg)](https://gitter.im/swimlane/ngx-charts?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/swimlane/ngx-charts.svg?branch=master)](https://travis-ci.org/swimlane/ngx-charts)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b097196f7f544412a79a99080a41bbc1)](https://www.codacy.com/app/Swimlane/ngx-charts?utm_source=github.com&utm_medium=referral&utm_content=swimlane/ngx-charts&utm_campaign=Badge_Grade)
 [![Test Coverage](https://codeclimate.com/github/swimlane/ngx-charts/badges/coverage.svg)](https://codeclimate.com/github/swimlane/ngx-charts/coverage)
 [![npm version](https://badge.fury.io/js/%40swimlane%2Fngx-charts.svg)](https://badge.fury.io/js/%40swimlane%2Fngx-charts)
 [![npm downloads](https://img.shields.io/npm/dm/@swimlane/ngx-charts.svg)](https://npmjs.org/@swimlane/ngx-charts)
 
 Declarative Charting Framework for Angular2 and beyond!
 
-ngx-charts is unique because we don't merely wrap d3, nor any other chart engine for that matter. It is using Angular to render and animate the SVG elements with all of its binding and speed goodness, and uses d3 for the excellent math functions, scales, axis and shape generators, etc. By having Angular do all of the rendering it opens us up to endless possibilities the Angular platform provides such as AoT, Universal, etc. 
+ngx-charts is unique because we don't merely wrap d3, nor any other chart engine for that matter. It is using Angular to render and animate the SVG elements with all of its binding and speed goodness, and uses d3 for the excellent math functions, scales, axis and shape generators, etc. By having Angular do all of the rendering it opens us up to endless possibilities the Angular platform provides such as AoT, Universal, etc.
 
 Data visualization is a science but that doesn't mean it has to be ugly. One of the big efforts we've made while creating this project is to make the charts aesthetically pleasing. The styles are also completely customizable through CSS, so you can override them as you please.
 
@@ -17,20 +18,23 @@ Also, constructing custom charts is possible by leveraging the various ngx-chart
 For more info, check out the [documentation](https://swimlane.gitbook.io/ngx-charts) and the [demos](https://swimlane.github.io/ngx-charts/).
 
 ## Features
+
 ### Chart Types
+
 - Horizontal & Vertical Bar Charts (Standard, Grouped, Stacked, Normalized)
-- Line 
+- Line
 - Area (Standard, Stacked, Normalized)
 - Pie (Explodable, Grid, Custom legends)
 - Bubble
 - Donut
 - Gauge (Linear & Radial)
-- Force Directed Graph
+- Force Directed Graph (deprecated - please use [ngx-graph](https://github.com/swimlane/ngx-graph) instead)
 - Heatmap
 - Treemap
 - Number Cards
 
 ### Customization
+
 - Autoscaling
 - Timeline Filtering
 - Line Interpolation
@@ -43,6 +47,7 @@ For more info, check out the [documentation](https://swimlane.gitbook.io/ngx-cha
 - Works with ngUpgrade
 
 ## Install
+
 To use ngx-charts in your project install it via [npm](https://www.npmjs.com/package/@swimlane/ngx-charts):
 
 ```
@@ -50,9 +55,11 @@ npm i @swimlane/ngx-charts --save
 ```
 
 ## Custom Charts
+
 To learn how to use the ngx-charts components to build custom charts and find examples, please refer to our [Custom Charts Page](https://github.com/swimlane/ngx-charts/blob/master/docs/custom-charts.md).
 
 ## Credits
+
 `ngx-charts` is a [Swimlane](http://swimlane.com) open-source project; we believe in giving back to the open-source community by sharing some of the projects we build for our application. Swimlane is an automated cyber security operations and incident response platform that enables cyber security teams to leverage threat intelligence, speed up incident response and automate security operations.
 
 [SecOps Hub](http://secopshub.com) is an open, product-agnostic, online community for security professionals to share ideas, use cases, best practices, and incident response strategies.

--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -32,7 +32,8 @@
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
         (select)="select($event)"
-        (legendLabelClick)="onLegendLabelClick($event)">
+        (legendLabelClick)="onLegendLabelClick($event)"
+      >
       </ngx-charts-bar-vertical>
       <ngx-charts-bar-horizontal
         *ngIf="chartType === 'bar-horizontal'"
@@ -64,7 +65,8 @@
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
         (legendLabelClick)="onLegendLabelClick($event)"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-horizontal>
       <ngx-charts-bar-vertical-2d
         *ngIf="chartType === 'bar-vertical-2d'"
@@ -97,7 +99,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-vertical-2d>
       <ngx-charts-bar-horizontal-2d
         *ngIf="chartType === 'bar-horizontal-2d'"
@@ -130,7 +133,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-horizontal-2d>
       <ngx-charts-bar-vertical-stacked
         *ngIf="chartType === 'bar-vertical-stacked'"
@@ -161,7 +165,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-vertical-stacked>
       <ngx-charts-bar-horizontal-stacked
         *ngIf="chartType === 'bar-horizontal-stacked'"
@@ -192,7 +197,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-horizontal-stacked>
       <ngx-charts-bar-vertical-normalized
         *ngIf="chartType === 'bar-vertical-normalized'"
@@ -221,7 +227,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-vertical-normalized>
       <ngx-charts-bar-horizontal-normalized
         *ngIf="chartType === 'bar-horizontal-normalized'"
@@ -250,7 +257,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-bar-horizontal-normalized>
       <ngx-charts-pie-chart
         *ngIf="chartType === 'pie-chart'"
@@ -271,7 +279,8 @@
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
         (dblclick)="dblclick($event)"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-pie-chart>
       <ngx-charts-advanced-pie-chart
         *ngIf="chartType === 'advanced-pie-chart'"
@@ -285,7 +294,8 @@
         [gradient]="gradient"
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-advanced-pie-chart>
       <ngx-charts-pie-grid
         *ngIf="chartType === 'pie-grid'"
@@ -297,7 +307,8 @@
         [animations]="animations"
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-pie-grid>
       <ngx-charts-line-chart
         *ngIf="chartType === 'line-chart'"
@@ -333,7 +344,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-line-chart>
       <ngx-charts-polar-chart
         *ngIf="chartType === 'polar-chart'"
@@ -363,7 +375,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxYAxisTickLength]="maxYAxisTickLength"
         [curve]="closedCurve"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-polar-chart>
       <ngx-charts-bubble-chart
         *ngIf="chartType === 'bubble-chart'"
@@ -395,23 +408,31 @@
         [trimXAxisTicks]="trimXAxisTicks"
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
-        [maxYAxisTickLength]="maxYAxisTickLength">
+        [maxYAxisTickLength]="maxYAxisTickLength"
+      >
       </ngx-charts-bubble-chart>
-      <ngx-charts-force-directed-graph
-        *ngIf="chartType === 'force-directed-graph'"
-        class="chart-container"
-        [legend]="showLegend"
-        [legendTitle]="legendTitle"
-        [legendPosition]="legendPosition"
-        [links]="graph.links"
-        [animations]="animations"
-        (legendLabelClick)="onLegendLabelClick($event)"
-        [nodes]="graph.nodes"
-        [scheme]="colorScheme"
-        [view]="view"
-        [tooltipDisabled]="tooltipDisabled"
-        (select)="select($event)">
-      </ngx-charts-force-directed-graph>
+      <div style="width: 100%; height: 100%" *ngIf="chartType === 'force-directed-graph'">
+        <ngx-charts-force-directed-graph
+          class="chart-container"
+          [legend]="showLegend"
+          [legendTitle]="legendTitle"
+          [legendPosition]="legendPosition"
+          [links]="graph.links"
+          [animations]="animations"
+          (legendLabelClick)="onLegendLabelClick($event)"
+          [nodes]="graph.nodes"
+          [scheme]="colorScheme"
+          [view]="view"
+          [tooltipDisabled]="tooltipDisabled"
+          (select)="select($event)"
+        >
+        </ngx-charts-force-directed-graph>
+        <p style="width: calc(100% - 300px)">
+          The force-directed chart type has been deprecated in favor of
+          <a href="https://github.com/swimlane/ngx-graph" target="_blank">ngx-graph</a> and will be removed in the next
+          major version. Please use ngx-graph instead
+        </p>
+      </div>
       <ngx-charts-area-chart
         *ngIf="chartType === 'area-chart'"
         class="chart-container"
@@ -445,7 +466,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-area-chart>
       <ngx-charts-area-chart-stacked
         *ngIf="chartType === 'area-chart-stacked'"
@@ -479,7 +501,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-area-chart-stacked>
       <ngx-charts-area-chart-normalized
         *ngIf="chartType === 'area-chart-normalized'"
@@ -509,7 +532,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-area-chart-normalized>
       <combo-chart-component
         *ngIf="chartType === 'combo-chart'"
@@ -538,7 +562,8 @@
         [xAxisLabel]="xAxisLabel"
         [yAxisLabel]="yAxisLabel"
         [yAxisLabelRight]="yAxisLabelRight"
-        (select)="onSelect($event)">
+        (select)="onSelect($event)"
+      >
       </combo-chart-component>
       <ngx-charts-heat-map
         *ngIf="chartType === 'heat-map'"
@@ -564,7 +589,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-heat-map>
       <ngx-charts-heat-map
         *ngIf="chartType === 'calendar'"
@@ -588,7 +614,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-heat-map>
       <ngx-charts-tree-map
         *ngIf="chartType === 'tree-map'"
@@ -602,7 +629,8 @@
         [labelFormatting]="gdpLabelFormatting"
         [valueFormatting]="currencyFormatting"
         [gradient]="gradient"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-tree-map>
       <ngx-charts-number-card
         *ngIf="chartType === 'number-card'"
@@ -614,7 +642,8 @@
         emptyColor="#1e222e"
         [results]="single"
         [animations]="animations"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-number-card>
       <div *ngIf="chartType === 'status-demo'">
         <ngx-slider
@@ -623,19 +652,21 @@
           [filled]="true"
           [min]="0"
           [max]="10000"
-          (change)="statusData = calcStatusData()">
+          (change)="statusData = calcStatusData()"
+        >
         </ngx-slider>
-        Price: ${{salePrice}}
-        <br/>
+        Price: ${{ salePrice }}
+        <br />
         <ngx-slider
           [(ngModel)]="personnelCost"
           [step]="100"
           [filled]="true"
           [min]="0"
           [max]="10000"
-          (change)="statusData = calcStatusData()">
+          (change)="statusData = calcStatusData()"
+        >
         </ngx-slider>
-        Cost: ${{personnelCost}} / hr
+        Cost: ${{ personnelCost }} / hr
         <ngx-charts-number-card
           class="chart-container"
           [view]="view"
@@ -646,7 +677,8 @@
           [results]="statusData"
           [animations]="animations"
           [valueFormatting]="statusValueFormat"
-          [labelFormatting]="statusLabelFormat">
+          [labelFormatting]="statusLabelFormat"
+        >
         </ngx-charts-number-card>
       </div>
       <ngx-charts-gauge
@@ -671,7 +703,8 @@
         [margin]="margin ? [marginTop, marginRight, marginBottom, marginLeft] : null"
         [tooltipDisabled]="tooltipDisabled"
         (select)="select($event)"
-        (legendLabelClick)="onLegendLabelClick($event)">
+        (legendLabelClick)="onLegendLabelClick($event)"
+      >
       </ngx-charts-gauge>
       <ngx-charts-linear-gauge
         *ngIf="chartType === 'linear-gauge'"
@@ -684,14 +717,16 @@
         [value]="gaugeValue"
         [previousValue]="gaugePreviousValue"
         [units]="gaugeUnits"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-linear-gauge>
       <div *ngIf="chartType === 'plot-demo'">
         <ngx-input
           type="text"
           [required]="true"
           [(ngModel)]="mathText"
-          (change)="mathFunction = getFunction(mathText); plotData = generatePlotData()">
+          (change)="mathFunction = getFunction(mathText); plotData = generatePlotData()"
+        >
         </ngx-input>
         <ngx-charts-line-chart
           style="position: static; display: inline-block; transform: none;"
@@ -723,7 +758,8 @@
           [trimYAxisTicks]="trimYAxisTicks"
           [maxXAxisTickLength]="maxXAxisTickLength"
           [maxYAxisTickLength]="maxYAxisTickLength"
-          (select)="select($event)">
+          (select)="select($event)"
+        >
         </ngx-charts-line-chart>
         <p></p>
         <ngx-charts-polar-chart
@@ -754,25 +790,27 @@
           [curve]="curves['Cardinal Closed']"
           [trimYAxisTicks]="trimYAxisTicks"
           [maxYAxisTickLength]="maxYAxisTickLength"
-          (select)="select($event)">
+          (select)="select($event)"
+        >
         </ngx-charts-polar-chart>
       </div>
-      <div class="chart-container"
-           *ngIf="chartType === 'tree-map-demo'"
-           style="padding: 10px; border: 1px solid white;">
+      <div
+        class="chart-container"
+        *ngIf="chartType === 'tree-map-demo'"
+        style="padding: 10px; border: 1px solid white;"
+      >
         <h4 style="text-align: center;">
-          <button class="btn btn-link" [class.active]="sumBy === 'Size'" (click)="treemapProcess('Size')">By Size
+          <button class="btn btn-link" [class.active]="sumBy === 'Size'" (click)="treemapProcess('Size')">
+            By Size
           </button>
-          <button class="btn btn-link" [class.active]="sumBy === 'Count'" (click)="treemapProcess('Count')">By Count
+          <button class="btn btn-link" [class.active]="sumBy === 'Count'" (click)="treemapProcess('Count')">
+            By Count
           </button>
         </h4>
         <div style="height: 17px; font-size: 12px;">
-          <ng-container *ngFor="let item of treemapPath; let last = last;">
-            <button
-              class="btn btn-link"
-              [class.active]="last"
-              [disabled]="last"
-              (click)="treemapSelect(item)">{{item.name}} ({{item.value}})
+          <ng-container *ngFor="let item of treemapPath; let last = last">
+            <button class="btn btn-link" [class.active]="last" [disabled]="last" (click)="treemapSelect(item)">
+              {{ item.name }} ({{ item.value }})
             </button>
             <span *ngIf="!last"> / </span>
           </ng-container>
@@ -785,7 +823,8 @@
           [animations]="animations"
           [tooltipDisabled]="tooltipDisabled"
           [gradient]="gradient"
-          (select)="treemapSelect($event)">
+          (select)="treemapSelect($event)"
+        >
         </ngx-charts-tree-map>
       </div>
       <ngx-charts-line-chart
@@ -821,7 +860,8 @@
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
-        (select)="select($event)">
+        (select)="select($event)"
+      >
       </ngx-charts-line-chart>
       <ngx-charts-bar-vertical
         *ngIf="chartType === 'tooltip-templates'"
@@ -851,22 +891,24 @@
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
         (select)="select($event)"
-        (legendLabelClick)="onLegendLabelClick($event)">
+        (legendLabelClick)="onLegendLabelClick($event)"
+      >
         <ng-template #tooltipTemplate let-model="model">
           <h1>
-            {{getFlag(model.name)}}
+            {{ getFlag(model.name) }}
           </h1>
-          <h2>{{model.name}}: {{model.value}}</h2>
+          <h2>{{ model.name }}: {{ model.value }}</h2>
         </ng-template>
       </ngx-charts-bar-vertical>
       <ngx-charts-sparkline
         *ngIf="chartType === 'sparkline'"
-        [view]="[100,50]"
+        [view]="[100, 50]"
         class="chart-container"
         [scheme]="'flame'"
         [results]="sparklineData"
         [animations]="animations"
-        [curve]="curve">
+        [curve]="curve"
+      >
       </ngx-charts-sparkline>
       <ngx-charts-timeline-filter-bar-chart
         *ngIf="chartType === 'timeline-filter-bar-chart-demo'"
@@ -884,7 +926,8 @@
         [xAxisLabel]="xAxisLabel"
         [yAxisLabel]="'Executions'"
         [showGridLines]="showGridLines"
-        (onFilter)="onFilter($event)">
+        (onFilter)="onFilter($event)"
+      >
       </ngx-charts-timeline-filter-bar-chart>
     </div>
     <ngx-charts-bar-vertical-stacked
@@ -916,7 +959,8 @@
       [trimYAxisTicks]="trimYAxisTicks"
       [maxXAxisTickLength]="maxXAxisTickLength"
       [maxYAxisTickLength]="maxYAxisTickLength"
-      (select)="select($event)">
+      (select)="select($event)"
+    >
     </ngx-charts-bar-vertical-stacked>
     <ngx-charts-bar-horizontal-stacked
       *ngIf="chartType === 'bar-horizontal-stacked-negative'"
@@ -946,100 +990,90 @@
       [trimYAxisTicks]="trimYAxisTicks"
       [maxXAxisTickLength]="maxXAxisTickLength"
       [maxYAxisTickLength]="maxYAxisTickLength"
-      (select)="select($event)">
+      (select)="select($event)"
+    >
     </ngx-charts-bar-horizontal-stacked>
   </div>
   <div class="sidebar">
     <h1>
       Ngx-<strong>Charts</strong>
-      <small class="version">{{version}}</small>
+      <small class="version">{{ version }}</small>
       <small class="subtitle">Angular D3 Chart Framework</small>
     </h1>
     <div style="margin:20px">
-
       <h3>Chart Type</h3>
-      <select
-        [ngModel]="chartType"
-        (ngModelChange)="selectChart($event)">
+      <select [ngModel]="chartType" (ngModelChange)="selectChart($event)">
         <ng-template ngFor let-group [ngForOf]="chartGroups">
           <optgroup [label]="group.name">
-            <option *ngFor="let chart of group.charts" [value]="chart.selector">{{chart.name}}</option>
+            <option *ngFor="let chart of group.charts" [value]="chart.selector">{{ chart.name }}</option>
           </optgroup>
         </ng-template>
       </select>
 
       <h3>Theme</h3>
-      <select
-        [ngModel]="theme"
-        (ngModelChange)="theme = $event">>
+      <select [ngModel]="theme" (ngModelChange)="theme = $event"
+        >>
         <option [value]="'dark'">Dark</option>
         <option [value]="'light'">Light</option>
       </select>
 
       <h3 (click)="dataVisable = !dataVisable" style="cursor: pointer">
-      <span
-        [class.arrow-down]="dataVisable"
-        [class.arrow-right]="!dataVisable">
-      </span>
+        <span [class.arrow-down]="dataVisable" [class.arrow-right]="!dataVisable"> </span>
         <strong>Data</strong>
       </h3>
       <div [hidden]="!dataVisable" style="margin-left: 10px;">
-        <pre *ngIf="chart.inputFormat === 'singleSeries'">{{single | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'multiSeries' && !linearScale">{{multi | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'multiSeriesNegative' && !linearScale">{{fiscalYearReport | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'multiSeries' && linearScale && (!range)">{{dateData | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'multiSeries' && linearScale && range">{{dateDataWithRange | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'bubble'">{{bubble | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'comboChart'">{{barChart | json}}</pre>
-        <pre *ngIf="chart.inputFormat === 'comboChart'">{{lineChartSeries | json}}</pre>
+        <pre *ngIf="chart.inputFormat === 'singleSeries'">{{ single | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'multiSeries' && !linearScale">{{ multi | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'multiSeriesNegative' && !linearScale">{{ fiscalYearReport | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'multiSeries' && linearScale && !range">{{ dateData | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'multiSeries' && linearScale && range">{{ dateDataWithRange | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'bubble'">{{ bubble | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'comboChart'">{{ barChart | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'comboChart'">{{ lineChartSeries | json }}</pre>
         <div>
           <label>
-            <input type="checkbox" [checked]="realTimeData" (change)="realTimeData = $event.target.checked">
+            <input type="checkbox" [checked]="realTimeData" (change)="realTimeData = $event.target.checked" />
             Real-time
           </label>
 
           <label *ngIf="chartType === 'line-chart'">
-            <br/>
-            <input type="checkbox" [checked]="range" (change)="range = $event.target.checked">
+            <br />
+            <input type="checkbox" [checked]="range" (change)="range = $event.target.checked" />
             Show min and max values
           </label>
         </div>
       </div>
       <div>
         <h3 (click)="dimVisiable = !dimVisiable" style="cursor: pointer">
-        <span
-          [class.arrow-down]="dimVisiable"
-          [class.arrow-right]="!dimVisiable">
-        </span>
+          <span [class.arrow-down]="dimVisiable" [class.arrow-right]="!dimVisiable"> </span>
           <strong>Dimensions</strong>
         </h3>
         <div [hidden]="!dimVisiable" style="margin-left: 10px;">
           <label>
-            <input type="checkbox" [checked]="fitContainer" (change)="toggleFitContainer($event.target.checked)">
+            <input type="checkbox" [checked]="fitContainer" (change)="toggleFitContainer($event.target.checked)" />
             Fit Container
-          </label> <br/>
+          </label>
+          <br />
           <div *ngIf="!fitContainer">
-            <label>Width:</label><br/>
-            <input type="number" [(ngModel)]="width"><br/>
-            <label>Height:</label><br/>
-            <input type="number" [(ngModel)]="height"><br/><br/>
+            <label>Width:</label><br />
+            <input type="number" [(ngModel)]="width" /><br />
+            <label>Height:</label><br />
+            <input type="number" [(ngModel)]="height" /><br /><br />
             <button class="btn btn-primary" (click)="applyDimensions()">Apply dimensions</button>
           </div>
         </div>
       </div>
       <h3 (click)="colorVisible = !colorVisible" style="cursor: pointer">
-      <span
-        [class.arrow-down]="colorVisible"
-        [class.arrow-right]="!colorVisible">
-      </span>
+        <span [class.arrow-down]="colorVisible" [class.arrow-right]="!colorVisible"> </span>
         <strong>Color Scheme</strong>
       </h3>
       <select
         [hidden]="!colorVisible"
         style="margin-left: 10px;"
         [ngModel]="selectedColorScheme"
-        (ngModelChange)="setColorScheme($event)">
-        <option *ngFor="let scheme of colorSets" [value]="scheme.name">{{scheme.name}}</option>
+        (ngModelChange)="setColorScheme($event)"
+      >
+        <option *ngFor="let scheme of colorSets" [value]="scheme.name">{{ scheme.name }}</option>
       </select>
 
       <select
@@ -1047,318 +1081,332 @@
         [hidden]="!colorVisible"
         style="margin-left: 10px;"
         [ngModel]="schemeType"
-        (ngModelChange)="schemeType = $event">
+        (ngModelChange)="schemeType = $event"
+      >
         <option value="ordinal">Ordinal</option>
         <option value="linear">Linear</option>
       </select>
 
-      <div [hidden]="(!colorVisible) || (!range)" style="margin-left: 10px;">
+      <div [hidden]="!colorVisible || !range" style="margin-left: 10px;">
         <div>
-          <label>Range fill color opacity (0.0 - 1.0):</label><br/>
-          <input type="number" [(ngModel)]="rangeFillOpacity"><br/>
+          <label>Range fill color opacity (0.0 - 1.0):</label><br />
+          <input type="number" [(ngModel)]="rangeFillOpacity" /><br />
         </div>
       </div>
 
       <h3 (click)="optsVisible = !optsVisible" style="cursor: pointer">
-      <span
-        [class.arrow-down]="optsVisible"
-        [class.arrow-right]="!optsVisible">
-      </span>
+        <span [class.arrow-down]="optsVisible" [class.arrow-right]="!optsVisible"> </span>
         <strong>Options</strong>
       </h3>
       <div [hidden]="!optsVisible" style="margin-left: 10px;">
         <div *ngIf="chart.options.includes('animations')">
           <label>
-            <input type="checkbox" [checked]="animations" (change)="animations = $event.target.checked">
+            <input type="checkbox" [checked]="animations" (change)="animations = $event.target.checked" />
             Animations
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showXAxis')">
           <label>
-            <input type="checkbox" [checked]="showXAxis" (change)="showXAxis = $event.target.checked">
+            <input type="checkbox" [checked]="showXAxis" (change)="showXAxis = $event.target.checked" />
             Show X Axis
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showRefLabels')">
           <label>
-            <input type="checkbox" [checked]="showRefLabels" (change)="showRefLabels = $event.target.checked">
+            <input type="checkbox" [checked]="showRefLabels" (change)="showRefLabels = $event.target.checked" />
             Show Reference Labels
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showRefLines')">
           <label>
-            <input type="checkbox" [checked]="showRefLines" (change)="showRefLines = $event.target.checked">
+            <input type="checkbox" [checked]="showRefLines" (change)="showRefLines = $event.target.checked" />
             Show Reference Lines
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showYAxis')">
           <label>
-            <input type="checkbox" [checked]="showYAxis" (change)="showYAxis = $event.target.checked">
+            <input type="checkbox" [checked]="showYAxis" (change)="showYAxis = $event.target.checked" />
             Show Y Axis
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showGridLines')">
           <label>
-            <input type="checkbox" [checked]="showGridLines" (change)="showGridLines = $event.target.checked">
+            <input type="checkbox" [checked]="showGridLines" (change)="showGridLines = $event.target.checked" />
             Show Grid Lines
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('roundDomains')">
           <label>
-            <input type="checkbox" [checked]="roundDomains" (change)="roundDomains = $event.target.checked">
+            <input type="checkbox" [checked]="roundDomains" (change)="roundDomains = $event.target.checked" />
             Round Domains
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('gradient')">
           <label>
-            <input type="checkbox" [checked]="gradient" (change)="gradient = $event.target.checked">
+            <input type="checkbox" [checked]="gradient" (change)="gradient = $event.target.checked" />
             Use Gradients
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showLegend')">
           <label>
-            <input type="checkbox" [checked]="showLegend" (change)="showLegend = $event.target.checked">
+            <input type="checkbox" [checked]="showLegend" (change)="showLegend = $event.target.checked" />
             Show Legend
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showDataLabel')">
           <label>
-            <input type="checkbox" [checked]="showDataLabel" (change)="showDataLabel = $event.target.checked">
+            <input type="checkbox" [checked]="showDataLabel" (change)="showDataLabel = $event.target.checked" />
             Show Data Label
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('roundEdges')">
           <label>
-            <input type="checkbox" [checked]="roundEdges" (change)="roundEdges = $event.target.checked">
+            <input type="checkbox" [checked]="roundEdges" (change)="roundEdges = $event.target.checked" />
             Round Bar Edges
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('legendTitle')">
-          <label>Legend Title:</label><br/>
-          <input type="text" [(ngModel)]="legendTitle"><br/>
+          <label>Legend Title:</label><br />
+          <input type="text" [(ngModel)]="legendTitle" /><br />
         </div>
         <div *ngIf="chart.options.includes('legendPosition')">
-          <label>Legend Position:</label><br/>
+          <label>Legend Position:</label><br />
           <select style="margin-left: 10px;" [(ngModel)]="legendPosition">
             <option value="right">Right</option>
-            <option value="below">Below</option>
-          </select><br/>
+            <option value="below">Below</option> </select
+          ><br />
         </div>
         <div *ngIf="chart.options.includes('tooltipDisabled')">
           <label>
-            <input type="checkbox" [checked]="tooltipDisabled" (change)="tooltipDisabled = $event.target.checked">
+            <input type="checkbox" [checked]="tooltipDisabled" (change)="tooltipDisabled = $event.target.checked" />
             Disable tooltip
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('showXAxisLabel')">
           <label>
-            <input type="checkbox" [checked]="showXAxisLabel" (change)="showXAxisLabel = $event.target.checked">
+            <input type="checkbox" [checked]="showXAxisLabel" (change)="showXAxisLabel = $event.target.checked" />
             Show X Axis Label
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('xAxisLabel')">
-          <label>X Axis Label:</label><br/>
-          <input type="text" [(ngModel)]="xAxisLabel"><br/>
+          <label>X Axis Label:</label><br />
+          <input type="text" [(ngModel)]="xAxisLabel" /><br />
         </div>
         <div *ngIf="chart.options.includes('showYAxisLabel')">
           <label>
-            <input type="checkbox" [checked]="showYAxisLabel" (change)="showYAxisLabel = $event.target.checked">
+            <input type="checkbox" [checked]="showYAxisLabel" (change)="showYAxisLabel = $event.target.checked" />
             Show Y Axis Label
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('yAxisLabel')">
-          <label>Y Axis Label:</label><br/>
-          <input type="text" [(ngModel)]="yAxisLabel"><br/>
+          <label>Y Axis Label:</label><br />
+          <input type="text" [(ngModel)]="yAxisLabel" /><br />
         </div>
         <div *ngIf="chart.options.includes('showLabels')">
           <label>
-            <input type="checkbox" [checked]="showLabels" (change)="showLabels = $event.target.checked">
+            <input type="checkbox" [checked]="showLabels" (change)="showLabels = $event.target.checked" />
             Show Labels
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('trimXAxisTicks')">
           <label>
-            <input type="checkbox" [checked]="trimXAxisTicks" (change)="trimXAxisTicks = $event.target.checked">
+            <input type="checkbox" [checked]="trimXAxisTicks" (change)="trimXAxisTicks = $event.target.checked" />
             Trim X Axis Ticks
-          </label> <br />
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('maxXAxisTickLength')">
           <label>Max X Axis Tick Length:</label><br />
-          <input type="text" [(ngModel)]="maxXAxisTickLength"><br />
+          <input type="text" [(ngModel)]="maxXAxisTickLength" /><br />
         </div>
         <div *ngIf="chart.options.includes('trimYAxisTicks')">
           <label>
-            <input type="checkbox" [checked]="trimYAxisTicks" (change)="trimYAxisTicks = $event.target.checked">
+            <input type="checkbox" [checked]="trimYAxisTicks" (change)="trimYAxisTicks = $event.target.checked" />
             Trim Y Axis Ticks
-          </label> <br />
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('maxYAxisTickLength')">
           <label>Max Y Axis Tick Length:</label><br />
-          <input type="text" [(ngModel)]="maxYAxisTickLength"><br />
+          <input type="text" [(ngModel)]="maxYAxisTickLength" /><br />
         </div>
         <div *ngIf="chart.options.includes('doughnut')">
           <label>
-            <input type="checkbox" [checked]="doughnut" (change)="doughnut = $event.target.checked">
+            <input type="checkbox" [checked]="doughnut" (change)="doughnut = $event.target.checked" />
             Doughnut
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('arcWidth') && doughnut">
-          <label>Arc width (fraction of radius):</label><br/>
-          <input type="number" [disabled]="!doughnut" [(ngModel)]="arcWidth"
-                 max="1" min="0" step="0.01"><br/>
+          <label>Arc width (fraction of radius):</label><br />
+          <input type="number" [disabled]="!doughnut" [(ngModel)]="arcWidth" max="1" min="0" step="0.01" /><br />
         </div>
         <div *ngIf="chart.options.includes('explodeSlices') && !doughnut">
           <label>
-            <input type="checkbox" [checked]="explodeSlices" (change)="explodeSlices = $event.target.checked">
+            <input type="checkbox" [checked]="explodeSlices" (change)="explodeSlices = $event.target.checked" />
             Explode Slices
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('autoScale')">
           <label>
-            <input type="checkbox" [checked]="autoScale" (change)="autoScale = $event.target.checked">
+            <input type="checkbox" [checked]="autoScale" (change)="autoScale = $event.target.checked" />
             Auto Scale
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('timeline')">
           <label>
-            <input type="checkbox" [checked]="timeline" (change)="timeline = $event.target.checked">
+            <input type="checkbox" [checked]="timeline" (change)="timeline = $event.target.checked" />
             Timeline
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('curve')">
           <label>Line Interpolation</label>
-          <select
-            [(ngModel)]="curveType"
-            (ngModelChange)="curve = getInterpolationType($event)">
+          <select [(ngModel)]="curveType" (ngModelChange)="curve = getInterpolationType($event)">
             <option *ngFor="let interpolationType of interpolationTypes" [value]="interpolationType">
-              {{interpolationType}}
+              {{ interpolationType }}
             </option>
           </select>
         </div>
         <div *ngIf="chart.options.includes('curveClosed')">
           <label>Line Interpolation</label>
-          <select
-            [(ngModel)]="closedCurveType"
-            (ngModelChange)="closedCurve = getInterpolationType($event)">
+          <select [(ngModel)]="closedCurveType" (ngModelChange)="closedCurve = getInterpolationType($event)">
             <option *ngFor="let interpolationType of closedInterpolationTypes" [value]="interpolationType">
-              {{interpolationType}}
+              {{ interpolationType }}
             </option>
           </select>
         </div>
         <div *ngIf="chart.options.includes('min')">
-          <label>Min value:</label><br/>
-          <input type="number" [(ngModel)]="gaugeMin"><br/>
+          <label>Min value:</label><br />
+          <input type="number" [(ngModel)]="gaugeMin" /><br />
         </div>
         <div *ngIf="chart.options.includes('max')">
-          <label>Max value:</label><br/>
-          <input type="number" [(ngModel)]="gaugeMax"><br/>
+          <label>Max value:</label><br />
+          <input type="number" [(ngModel)]="gaugeMax" /><br />
         </div>
         <div *ngIf="chart.options.includes('innerPadding')">
-          <label>Inner padding value:</label><br/>
-          <input type="text" [(ngModel)]="innerPadding" min="0" step="1"><br/>
+          <label>Inner padding value:</label><br />
+          <input type="text" [(ngModel)]="innerPadding" min="0" step="1" /><br />
         </div>
         <div *ngIf="chart.options.includes('barPadding')">
-          <label>Padding between bars:</label><br/>
-          <input type="number" [(ngModel)]="barPadding" min="0" step="1"><br/>
+          <label>Padding between bars:</label><br />
+          <input type="number" [(ngModel)]="barPadding" min="0" step="1" /><br />
         </div>
         <div *ngIf="chart.options.includes('groupPadding')">
-          <label>Padding between groups:</label><br/>
-          <input type="number" [(ngModel)]="groupPadding" min="0" step="1"><br/>
+          <label>Padding between groups:</label><br />
+          <input type="number" [(ngModel)]="groupPadding" min="0" step="1" /><br />
         </div>
         <div *ngIf="chart.options.includes('value')">
-          <label>Value:</label><br/>
-          <input type="number" [(ngModel)]="gaugeValue"><br/>
+          <label>Value:</label><br />
+          <input type="number" [(ngModel)]="gaugeValue" /><br />
         </div>
         <div *ngIf="chart.options.includes('previousValue')">
-          <label>Previous value:</label><br/>
-          <input type="number" [(ngModel)]="gaugePreviousValue"><br/>
+          <label>Previous value:</label><br />
+          <input type="number" [(ngModel)]="gaugePreviousValue" /><br />
         </div>
         <div *ngIf="chart.options.includes('angleSpan')">
-          <label>Angle span:</label><br/>
-          <input type="number" [(ngModel)]="gaugeAngleSpan"><br/>
+          <label>Angle span:</label><br />
+          <input type="number" [(ngModel)]="gaugeAngleSpan" /><br />
         </div>
         <div *ngIf="chart.options.includes('startAngle')">
-          <label>Start Angle:</label><br/>
-          <input type="number" [(ngModel)]="gaugeStartAngle"><br/>
+          <label>Start Angle:</label><br />
+          <input type="number" [(ngModel)]="gaugeStartAngle" /><br />
         </div>
         <div *ngIf="chart.options.includes('showAxis')">
           <label>
-            <input type="checkbox" [checked]="gaugeShowAxis" (change)="gaugeShowAxis = $event.target.checked">
+            <input type="checkbox" [checked]="gaugeShowAxis" (change)="gaugeShowAxis = $event.target.checked" />
             Show Axis
-          </label> <br/>
+          </label>
+          <br />
         </div>
         <div *ngIf="chart.options.includes('largeSegments')">
-          <label>Number of large segments:</label><br/>
-          <input type="number" [(ngModel)]="gaugeLargeSegments"><br/>
+          <label>Number of large segments:</label><br />
+          <input type="number" [(ngModel)]="gaugeLargeSegments" /><br />
         </div>
         <div *ngIf="chart.options.includes('smallSegments')">
-          <label>Number of small segments:</label><br/>
-          <input type="number" [(ngModel)]="gaugeSmallSegments"><br/>
+          <label>Number of small segments:</label><br />
+          <input type="number" [(ngModel)]="gaugeSmallSegments" /><br />
         </div>
         <div *ngIf="chart.options.includes('units')">
-          <label>Units:</label><br/>
-          <input type="text" [(ngModel)]="gaugeUnits"><br/>
+          <label>Units:</label><br />
+          <input type="text" [(ngModel)]="gaugeUnits" /><br />
         </div>
         <div *ngIf="chart.options.includes('margin')">
           <label>
-            <input type="checkbox" [checked]="margin" (change)="margin = $event.target.checked">
+            <input type="checkbox" [checked]="margin" (change)="margin = $event.target.checked" />
             Show Margin
-          </label> <br/>
+          </label>
+          <br />
         </div>
 
         <div *ngIf="chart.options.includes('margin') && margin">
-          <label>Top:</label><input type="number" [(ngModel)]="marginTop"><br/>
-          <label>Right:</label><input type="number" [(ngModel)]="marginRight"><br/>
-          <label>Bottom:</label><input type="number" [(ngModel)]="marginBottom"><br/>
-          <label>Left:</label><input type="number" [(ngModel)]="marginLeft"><br/>
+          <label>Top:</label><input type="number" [(ngModel)]="marginTop" /><br />
+          <label>Right:</label><input type="number" [(ngModel)]="marginRight" /><br />
+          <label>Bottom:</label><input type="number" [(ngModel)]="marginBottom" /><br />
+          <label>Left:</label><input type="number" [(ngModel)]="marginLeft" /><br />
         </div>
 
         <div *ngIf="chart.options.includes('minRadius')">
-          <label>Minimum Radius:</label><input type="number" [(ngModel)]="minRadius">
+          <label>Minimum Radius:</label><input type="number" [(ngModel)]="minRadius" />
         </div>
 
         <div *ngIf="chart.options.includes('maxRadius')">
-          <label>Maximum Radius:</label><input type="number" [(ngModel)]="maxRadius">
+          <label>Maximum Radius:</label><input type="number" [(ngModel)]="maxRadius" />
         </div>
 
         <div *ngIf="chart.options.includes('xScaleMin')">
           <div *ngIf="chartType !== 'bubble-chart'">
-            <label></label><br/>
-            <ngx-date-time
-              [inputType]="'datetime'"
-              label="Minimum X-Scale value"
-              [(ngModel)]="xScaleMin">
+            <label></label><br />
+            <ngx-date-time [inputType]="'datetime'" label="Minimum X-Scale value" [(ngModel)]="xScaleMin">
             </ngx-date-time>
           </div>
           <div *ngIf="chartType === 'bubble-chart'">
-            <label>Minimum X-Scale value</label><br/>
-            <input type="number" [(ngModel)]="xScaleMin"><br/>
+            <label>Minimum X-Scale value</label><br />
+            <input type="number" [(ngModel)]="xScaleMin" /><br />
           </div>
         </div>
 
         <div *ngIf="chart.options.includes('xScaleMax')">
           <div *ngIf="!chartType.startsWith('bar-horizontal') && chartType !== 'bubble-chart'">
-            <ngx-date-time *ngIf="!chartType.startsWith('bar-horizontal')"
-                           [inputType]="'datetime'"
-                           label="Maximum X-Scale value"
-                           [(ngModel)]="xScaleMax">
+            <ngx-date-time
+              *ngIf="!chartType.startsWith('bar-horizontal')"
+              [inputType]="'datetime'"
+              label="Maximum X-Scale value"
+              [(ngModel)]="xScaleMax"
+            >
             </ngx-date-time>
           </div>
           <div *ngIf="chartType.startsWith('bar-horizontal') || chartType === 'bubble-chart'">
-            <label>Maximum X-Scale value</label><br/>
-            <input type="number" [(ngModel)]="xScaleMax"><br/>
+            <label>Maximum X-Scale value</label><br />
+            <input type="number" [(ngModel)]="xScaleMax" /><br />
           </div>
         </div>
 
         <div *ngIf="chart.options.includes('yScaleMin')">
-          <label>Minimum Y-Scale value</label><br/>
-          <input type="number" [(ngModel)]="yScaleMin"><br/>
+          <label>Minimum Y-Scale value</label><br />
+          <input type="number" [(ngModel)]="yScaleMin" /><br />
         </div>
         <div *ngIf="chart.options.includes('yScaleMax')">
-          <label>Maximum Y-Scale value</label><br/>
-          <input type="number" [(ngModel)]="yScaleMax"><br/>
+          <label>Maximum Y-Scale value</label><br />
+          <input type="number" [(ngModel)]="yScaleMax" /><br />
         </div>
-
       </div>
       <h3><a href="https://swimlane.gitbooks.io/ngx-charts/content/" target="_blank">Documentation</a></h3>
     </div>

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -535,7 +535,7 @@ const chartGroups = [
         }
       },
       {
-        name: 'Force Directed Graph',
+        name: 'Force Directed Graph (deprecated)',
         selector: 'force-directed-graph',
         inputFormat: 'graph',
         options: ['animations', 'colorScheme', 'showLegend', 'legendTitle', 'legendPosition', 'tooltipDisabled']

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,33 +4,33 @@ Out of the box, we wanted to create a low level robust framework on which to bui
 
 ### Chart Types
 
-* Horizontal & Vertical Bar Charts \(Standard, Grouped, Stacked, Normalized\)
-* Line 
-* Area \(Standard, Stacked, Normalized\)
-* Pie \(Explodable, Grid, Custom legends\)
-* Donut
-* Gauge
-* Linear Gauge
-* Force Directed Graph
-* Heatmap
-* Treemap
-* Number Cards
-* Bubble/Scatter
+- Horizontal & Vertical Bar Charts \(Standard, Grouped, Stacked, Normalized\)
+- Line
+- Area \(Standard, Stacked, Normalized\)
+- Pie \(Explodable, Grid, Custom legends\)
+- Donut
+- Gauge
+- Linear Gauge
+- Force Directed Graph (deprecated - please use [ngx-graph](https://github.com/swimlane/ngx-graph) instead)
+- Heatmap
+- Treemap
+- Number Cards
+- Bubble/Scatter
 
 ### Customization
 
-* Autoscaling
-* Timeline Filtering
-* Line Interpolation
-* Configurable Axis Labels
-* Legends \(Labels & Gradient\)
-* Advanced Label Positioning
-* Real-time data support
-* Advanced Tooltips
-* Responsive Layout
-* Data point Event Handlers
-* Works with ngUpgrade
-* Enabling/Disabling animations
+- Autoscaling
+- Timeline Filtering
+- Line Interpolation
+- Configurable Axis Labels
+- Legends \(Labels & Gradient\)
+- Advanced Label Positioning
+- Real-time data support
+- Advanced Tooltips
+- Responsive Layout
+- Data point Event Handlers
+- Works with ngUpgrade
+- Enabling/Disabling animations
 
 If you have an idea for a new feature, create a Github issue or even better a PR ;\). Make sure to include the use case, an example image of the chart \(if applicable\) and data formats.
 
@@ -38,14 +38,13 @@ If you have an idea for a new feature, create a Github issue or even better a PR
 
 Chart frameworks are a dime a dozen nowadays. Not many of them existed a few years ago when we started this project internally and many of them still don't really work well with Angular. Here's a recent list we compiled during our effort to open-source this:
 
-* [ng2-nvd3](https://github.com/krispo/ng2-nvd3) - Open-source wrapper for nvd3 using Angular2 Components
-* [ng2-charts](http://valor-software.com/ng2-charts/) - Open-source Angular2 wrapper directives for Chart.js
-* [angular2-highcharts](https://www.npmjs.com/package/angular2-highcharts) - Open-source Angular2 wrapper for HighCharts
-* [recharts](http://recharts.org/) - Open-source composable charting library built on React components
-* [Vega](http://vega.github.io/) - Open-source Canvas/SVG viz framework
-* [C3](http://c3js.org/) - Open-source D3-based reusable chart library
-* [Plotly](https://plot.ly/) - Commercial business intelligence and data science.
-* [Highcharts](http://www.highcharts.com/) - Commercial chart framework
-* [eCharts](http://echarts.baidu.com/demo.htm) - Open-source JavaScript chart framework
-* [dc.js](http://dc-js.github.io/dc.js) - Open-source JavaScript charting library
-
+- [ng2-nvd3](https://github.com/krispo/ng2-nvd3) - Open-source wrapper for nvd3 using Angular2 Components
+- [ng2-charts](http://valor-software.com/ng2-charts/) - Open-source Angular2 wrapper directives for Chart.js
+- [angular2-highcharts](https://www.npmjs.com/package/angular2-highcharts) - Open-source Angular2 wrapper for HighCharts
+- [recharts](http://recharts.org/) - Open-source composable charting library built on React components
+- [Vega](http://vega.github.io/) - Open-source Canvas/SVG viz framework
+- [C3](http://c3js.org/) - Open-source D3-based reusable chart library
+- [Plotly](https://plot.ly/) - Commercial business intelligence and data science.
+- [Highcharts](http://www.highcharts.com/) - Commercial chart framework
+- [eCharts](http://echarts.baidu.com/demo.htm) - Open-source JavaScript chart framework
+- [dc.js](http://dc-js.github.io/dc.js) - Open-source JavaScript charting library


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

A while back, we saw the need for a more advanced library to visualise graph data in angular. The force-directed chart did that, but in a limited way and was lacking features, so we decided to build a better graph visualisation component.

Additionally, graph visualisation is a huge field on its own, so we felt it would be better to split the component into its own package, so we created [@swimlane/ngx-graph](https://github.com/swimlane/ngx-graph)

In ngx-graph v6, we added the option for customisable graph layout, so now it can do everything that the force-directed chart does, and much more. 

This is why we are deprecating the force-directed chart, and recommend replacing it with @swimlane/ngx-graph instead. 

The force-directed chart will still work in version 11.x, but will be removed in the next major version (12.x). This PR only updates the documentation.

**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No

