### PR TITLE
Fix line chart scaling on combo charts with large domain

### DIFF
--- a/demo/combo-chart/combo-chart.component.ts
+++ b/demo/combo-chart/combo-chart.component.ts
@@ -254,8 +254,7 @@ export class ComboChartComponent extends BaseChartComponent {
     this.yDomainLine = this.getYDomainLine();
     this.seriesDomain = this.getSeriesDomain();
 
-    this.xScaleLine = this.getXScaleLine(this.xDomainLine, this.dims.width);
-    this.yScaleLine = this.getYScaleLine(this.yDomainLine, this.dims.height);
+    this.scaleLines();
 
     this.setColors();
     this.legendOptions = this.getLegendOptions();
@@ -286,6 +285,11 @@ export class ComboChartComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomainLine = this.filteredDomain;
     this.xScaleLine = this.getXScaleLine(this.xDomainLine, this.dims.width);
+  }
+
+  scaleLines() {
+    this.xScaleLine = this.getXScaleLine(this.xDomainLine, this.dims.width);
+    this.yScaleLine = this.getYScaleLine(this.yDomainLine, this.dims.height);
   }
 
   getSeriesDomain(): any[] {
@@ -390,8 +394,9 @@ export class ComboChartComponent extends BaseChartComponent {
   getXScaleLine(domain, width): any {
     let scale;
     if (this.bandwidth === undefined) {
-      this.bandwidth = this.dims.width - this.barPadding;
+      this.bandwidth = width - this.barPadding;
     }
+    const offset = Math.floor((width + this.barPadding - (this.bandwidth + this.barPadding) * domain.length) / 2);
 
     if (this.scaleType === 'time') {
       scale = scaleTime()
@@ -407,7 +412,7 @@ export class ComboChartComponent extends BaseChartComponent {
       }
     } else if (this.scaleType === 'ordinal') {
       scale = scalePoint()
-        .range([this.bandwidth / 2, width - this.bandwidth / 2])
+        .range([offset + this.bandwidth / 2, width - offset - this.bandwidth / 2])
         .domain(domain);
     }
 
@@ -491,6 +496,7 @@ export class ComboChartComponent extends BaseChartComponent {
 
   updateLineWidth(width): void {
     this.bandwidth = width;
+    this.scaleLines();
   }
 
   updateYAxisWidth({ width }): void {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The bar chart in the combo chart always uses the integer width of the bar and in case of a large domain, it can contain additional offsets by sides. But the line chart doesn't take these offsets.

**What is the new behavior?**

Now the `getXScaleLine` call has calculated the offset of the bar chart and used it for correction of the line chart. The updating of the bar width is calling the scaling of the line chart also.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
