### PR TITLE
checkout for undefined xScale in groupTransform

### DIFF
--- a/src/bar-chart/bar-vertical-stacked.component.ts
+++ b/src/bar-chart/bar-vertical-stacked.component.ts
@@ -273,7 +273,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   }
 
   groupTransform(group) {
-    return `translate(${this.xScale(group.name)}, 0)`;
+    return `translate(${this.xScale(group.name) || 0}, 0)`;
   }
 
   onClick(data, group?) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Getting a console error when using `BarVerticalStackedComponent`.

**What is the new behavior?**

Error is gone after defaulting to `0` if `xScale()` returns undefined.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
