### PR TITLE
Update d3-time-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,6 @@
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
     "d3-shape": "^1.2.0",
-    "d3-time-format": "^2.1.0"
+    "d3-time-format": "2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -194,6 +194,6 @@
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
     "d3-shape": "^1.2.0",
-    "d3-time-format": "2.1.3"
+    "d3-time-format": "^2.1.3"
   }
 }


### PR DESCRIPTION
I've a problem on production: ERROR TypeError: Cannot read property 'getColor' of undefined
Because we don't use 2.1.3 version of d3-time-format.
Please check it!

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
