### PR TITLE
Add max-width to bar-vertical-stacked chart and put in center

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
@@ -134,6 +134,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
   @Input() noBarWhenZero: boolean = true;
+  @Input() barMaxWidth: number = 100;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -248,8 +249,10 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
 
   getXScale(): any {
     const spacing = this.groupDomain.length / (this.dims.width / this.barPadding + 1);
+    const maxWidth = Math.min(this.barMaxWidth * this.groupDomain.length, this.dims.width);
+
     return scaleBand()
-      .rangeRound([0, this.dims.width])
+      .rangeRound([0, this.barMaxWidth ? maxWidth : this.dims.width])
       .paddingInner(spacing)
       .domain(this.groupDomain);
   }

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.spec.ts
@@ -122,3 +122,31 @@ describe('<ngx-charts-bar-vertical>', () => {
     }));
   });
 });
+
+describe('bar-max-width', () => {
+
+  it('should render correct cell size, with zero padding, but fixed width', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+             <ngx-charts-bar-vertical
+              [view]="[400,800]"
+              [scheme]="colorScheme"
+              [results]="single"
+              [barPadding]="0"
+              [barMaxWidth]="30">
+            </ngx-charts-bar-vertical>`
+      }
+    });
+
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const bar = fixture.debugElement.query(By.directive(BarComponent));
+
+      expect(bar.componentInstance.width).toEqual(30);
+    });
+  }));
+
+});

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.ts
@@ -118,6 +118,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
   @Input() noBarWhenZero: boolean = true;
+  @Input() barMaxWidth: number;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -177,9 +178,12 @@ export class BarVerticalComponent extends BaseChartComponent {
   getXScale(): any {
     this.xDomain = this.getXDomain();
     const spacing = this.xDomain.length / (this.dims.width / this.barPadding + 1);
+    const maxWidth = Math.min(this.barMaxWidth * this.xDomain.length, this.dims.width);
+
     return scaleBand()
-      .range([0, this.dims.width])
+      .rangeRound([0, this.barMaxWidth ? maxWidth : this.dims.width])
       .paddingInner(spacing)
+      .align(0)
       .domain(this.xDomain);
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The bar chart extend through the whole container's width

**What is the new behavior?**

1. Limit each bar graph with max-width
2. Put in the center of container

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:

It's base on another PR https://github.com/swimlane/ngx-charts/pull/901 but haven't get approved.

For now, you will need to give a ref for your container
And assign it to injectionService. 
ex:
```
<div #chartContainer>
            <!--  ngx-charts-bar-vertical-stacked -->
</div>

class MyComponent implements AfterViewInit {
    @ViewChild('chartContainer', { read: ViewContainerRef }) public chartContainer: ViewContainerRef;

    constructor(private readonly injectionService: ɵb) { }
    
    public ngAfterViewInit(): void {
        this.injectionService.setRootViewContainer(this.chartContainer);
    }
}
```

There must have a better approach for assigning #chartContainer ref like do it inside the library.