### PR TITLE
Add minRadiusPerArc option instead of hardcoded 10 value

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
@@ -94,6 +94,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
   @Input() showAxis: boolean = true;
   @Input() startAngle: number = -120;
   @Input() angleSpan: number = 240;
+  @Input() minRadiusPerArc: number = 10;
   @Input() activeEntries: any[] = [];
   @Input() axisTickFormatting: any;
   @Input() tooltipDisabled: boolean = false;
@@ -186,7 +187,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
 
     const availableRadius = this.outerRadius * 0.7;
 
-    const radiusPerArc = Math.min(availableRadius / this.results.length, 10);
+    const radiusPerArc = Math.min(availableRadius / this.results.length, this.minRadiusPerArc);
     const arcWidth = radiusPerArc * 0.7;
     this.textRadius = this.outerRadius - this.results.length * radiusPerArc;
     this.cornerRadius = Math.floor(arcWidth / 2);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
minRadiusPerArc is hardcoded (value 10)


**What is the new behavior?**
Pass minRadiusPerArc as an @Input. It keeps default value to 10 to not break anything


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
