### PR TITLE
add grid-line ngStyle by axis tick value decorators to line chart

### DIFF
--- a/docs/examples/line-area-charts/line-chart.md
+++ b/docs/examples/line-area-charts/line-chart.md
@@ -50,7 +50,8 @@
 | xScaleMax             | any                |               | the maximum value of the x axis \(if the x scale is linear or time\)                                                                                                                                                                       |
 | yScaleMin             | number             |               | the minimum value of the y axis                                                                                                                                                                                                            |
 | yScaleMax             | number             |               | the maximum value of the y axis                                                                                                                                                                                                            |
-
+| gridLineNgStyleByXAxisTick | function      |               | the function which returns the ngStyle expression to apply on line grid based on xAxis tick value 
+| gridLineNgStyleByYAxisTick | function      |               | the function which returns the ngStyle expression to apply on line grid based on yAxis tick value
 ## Outputs
 
 | Property   | Description                                |

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis-ticks.component.ts
@@ -32,7 +32,12 @@ import { reduceTicks } from './ticks.helper';
 
     <svg:g *ngFor="let tick of ticks" [attr.transform]="tickTransform(tick)">
       <svg:g *ngIf="showGridLines" [attr.transform]="gridLineTransform()">
-        <svg:line class="gridline-path gridline-path-vertical" [attr.y1]="-gridLineHeight" y2="0" />
+        <svg:line
+          class="gridline-path gridline-path-vertical"
+          [ngStyle]="gridLineNgStyleByAxisTick ? gridLineNgStyleByAxisTick(tick) : null"
+          [attr.y1]="-gridLineHeight"
+          y2="0"
+        />
       </svg:g>
     </svg:g>
   `,
@@ -48,6 +53,7 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() maxTickLength: number = 16;
   @Input() tickFormatting;
   @Input() showGridLines = false;
+  @Input() gridLineNgStyleByAxisTick;
   @Input() gridLineHeight;
   @Input() width;
   @Input() rotateTicks: boolean = true;

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis.component.ts
@@ -27,6 +27,7 @@ import { XAxisTicksComponent } from './x-axis-ticks.component';
         [scale]="xScale"
         [orient]="xOrient"
         [showGridLines]="showGridLines"
+        [gridLineNgStyleByAxisTick]="gridLineNgStyleByAxisTick"
         [gridLineHeight]="dims.height"
         [width]="dims.width"
         [tickValues]="ticks"
@@ -53,6 +54,7 @@ export class XAxisComponent implements OnChanges {
   @Input() maxTickLength: number;
   @Input() tickFormatting;
   @Input() showGridLines = false;
+  @Input() gridLineNgStyleByAxisTick;
   @Input() showLabel;
   @Input() labelText;
   @Input() ticks: any[];

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
@@ -44,6 +44,7 @@ import { roundedRect } from '../../common/shape.helper';
         <svg:line
           *ngIf="orient === 'left'"
           class="gridline-path gridline-path-horizontal"
+          [ngStyle]="gridLineNgStyleByAxisTick ? gridLineNgStyleByAxisTick(tick) : null"
           x1="0"
           [attr.x2]="gridLineWidth"
         />
@@ -91,6 +92,7 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() maxTickLength: number = 16;
   @Input() tickFormatting;
   @Input() showGridLines = false;
+  @Input() gridLineNgStyleByAxisTick;
   @Input() gridLineWidth;
   @Input() height;
   @Input() referenceLines;

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
@@ -26,6 +26,7 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
         [scale]="yScale"
         [orient]="yOrient"
         [showGridLines]="showGridLines"
+        [gridLineNgStyleByAxisTick]="gridLineNgStyleByAxisTick"
         [gridLineWidth]="dims.width"
         [referenceLines]="referenceLines"
         [showRefLines]="showRefLines"
@@ -55,6 +56,7 @@ export class YAxisComponent implements OnChanges {
   @Input() tickFormatting;
   @Input() ticks: any[];
   @Input() showGridLines = false;
+  @Input() gridLineNgStyleByAxisTick;
   @Input() showLabel;
   @Input() labelText;
   @Input() yAxisTickInterval;

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -48,6 +48,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
           [xScale]="xScale"
           [dims]="dims"
           [showGridLines]="showGridLines"
+          [gridLineNgStyleByAxisTick]="gridLineNgStyleByXAxisTick"
           [showLabel]="showXAxisLabel"
           [labelText]="xAxisLabel"
           [trimTicks]="trimXAxisTicks"
@@ -63,6 +64,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
           [yScale]="yScale"
           [dims]="dims"
           [showGridLines]="showGridLines"
+          [gridLineNgStyleByAxisTick]="gridLineNgStyleByYAxisTick"
           [showLabel]="showYAxisLabel"
           [labelText]="yAxisLabel"
           [trimTicks]="trimYAxisTicks"
@@ -187,6 +189,8 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() timeline;
   @Input() gradient: boolean;
   @Input() showGridLines: boolean = true;
+  @Input() gridLineNgStyleByXAdxisTick;
+  @Input() gridLineNgStyleByYAxisTick;
   @Input() curve: any = curveLinear;
   @Input() activeEntries: any[] = [];
   @Input() schemeType: string;


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?**

add `gridLineNgStyleByXAxisTick` and `gridLineNgStyleByYAxisTick` decorators to line chart allowing specific format base on axis tick values

[stackblitz DEMO](https://stackblitz.com/edit/ngx-charts-gridlinengstylebyaxistick)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
