### PR TITLE
add customColors to heatmap

### DIFF
--- a/docs/examples/heat-map-chart.md
+++ b/docs/examples/heat-map-chart.md
@@ -12,6 +12,7 @@
 | results             | object\[\]           |                | the chart data                                                                                                    |
 | scheme              | object               |                | the color scheme of the chart                                                                                     |
 | animations          | boolean              | true           | enable animations                                                                                                 |
+| customColors        | function or object   |                | custom colors for the chart. Used to override a color for a specific value                                        |
 | legend              | boolean              | false          | show or hide the legend                                                                                           |
 | legendTitle         | string               | 'Legend'       | the legend title                                                                                                  |
 | legendPosition      | string               | 'right'        | the legend position ['right', 'below']                                                                            |

--- a/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map.component.ts
@@ -286,7 +286,7 @@ export class HeatMapComponent extends BaseChartComponent {
   }
 
   setColors(): void {
-    this.colors = new ColorHelper(this.scheme, this.scaleType, this.valueDomain);
+    this.colors = new ColorHelper(this.scheme, this.scaleType, this.valueDomain, this.customColors);
   }
 
   getLegendOptions() {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
 Currently, the heatmap does not allow for colors to be set by a particular value (known as customColors in other charts) (#756)


**What is the new behavior?**
Add support for `customColors` input for the heatmap, which is already supported by the `ColorHelper` class


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
