### PR TITLE
Fixed bug where hiding Y Axis would also hide reference lines

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
@@ -17,7 +17,7 @@ import { roundedRect } from '../../common/shape.helper';
 @Component({
   selector: 'g[ngx-charts-y-axis-ticks]',
   template: `
-    <svg:g #ticksel>
+    <svg:g #ticksel *ngIf="showYAxis">
       <svg:g *ngFor="let tick of ticks" class="tick" [attr.transform]="transform(tick)">
         <title>{{ tickFormat(tick) }}</title>
         <svg:text
@@ -82,6 +82,7 @@ import { roundedRect } from '../../common/shape.helper';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class YAxisTicksComponent implements OnChanges, AfterViewInit {
+  @Input() showYAxis: boolean = true;
   @Input() scale;
   @Input() orient;
   @Input() tickArguments = [5];

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
@@ -17,6 +17,7 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
       <svg:g
         ngx-charts-y-axis-ticks
         *ngIf="yScale"
+        [showYAxis]="showYAxis"
         [trimTicks]="trimTicks"
         [maxTickLength]="maxTickLength"
         [tickFormatting]="tickFormatting"
@@ -36,7 +37,7 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
 
       <svg:g
         ngx-charts-axis-label
-        *ngIf="showLabel"
+        *ngIf="showLabel && showYAxis"
         [label]="labelText"
         [offset]="labelOffset"
         [orient]="yOrient"
@@ -48,6 +49,7 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class YAxisComponent implements OnChanges {
+  @Input() showYAxis: boolean = true;
   @Input() yScale;
   @Input() dims;
   @Input() trimTicks: boolean;

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -59,7 +59,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
         ></svg:g>
         <svg:g
           ngx-charts-y-axis
-          *ngIf="yAxis"
+          [showYAxis]="yAxis"
           [yScale]="yScale"
           [dims]="dims"
           [showGridLines]="showGridLines"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
To me it looks like the reference lines should be refactored out of the `y-axis-ticks` component into a new component. Specially given the open issues requesting other charts to support this.
However, this is a fix for the current issue pointed on #1451 with very little changes.