### PR TITLE
feat: add line-chart onDomainChange Output and timeline liveOnDomainChange Input

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/timeline/timeline.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/timeline/timeline.component.ts
@@ -48,6 +48,7 @@ export class Timeline implements OnChanges {
   @Input() autoScale;
   @Input() scaleType;
   @Input() height: number = 50;
+  @Input() liveOnDomainChange = true;
 
   @Output() select = new EventEmitter();
   @Output() onDomainChange = new EventEmitter();
@@ -142,13 +143,14 @@ export class Timeline implements OnChanges {
 
     const height = this.height;
     const width = this.view[0];
+    const brushEvents = this.liveOnDomainChange ? 'brush end' : 'end';
 
     this.brush = brushX()
       .extent([
         [0, 0],
         [width, height]
       ])
-      .on('brush end', () => {
+      .on(brushEvents, () => {
         const selection = d3event.selection || this.xScale.range();
         const newDomain = selection.map(this.xScale.invert);
 

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -212,6 +212,7 @@ export class LineChartComponent extends BaseChartComponent {
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
+  @Output() onDomainChange: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
   @ContentChild('seriesTooltipTemplate') seriesTooltipTemplate: TemplateRef<any>;
@@ -404,6 +405,7 @@ export class LineChartComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomain = this.filteredDomain;
     this.xScale = this.getXScale(this.xDomain, this.dims.width);
+    this.onDomainChange.emit(this.filteredDomain);
   }
 
   updateHoveredVertical(item): void {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
`line-chart.component.ts`: Does not expose onDomainChange events from `timeline.component.ts`
`timeline.component.ts`: Emits an `onDomainChange` event every time the user adjusts the brush while selecting a time window in the timeline.

**What is the new behavior?**
`line-chart.component.ts`: Exposes onDomainChange events from `timeline.component.ts` as an Output
`timeline.component.ts`: Now has an option to only emit an `onDomainChange` event when the user is finished adjusting the brush while selecting a time window in the timeline.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Motivation for change: When using the ngx-charts-line-chart component with the timeline, I would like to be able to see the bounds of the time span that the user has selected. In addition, the current onDomainChanges event fires as the user changes the domain, I would like an option on the timeline component that can limit this to just emit an event when the selection ends.

For my use case, I have an accompanying table that has more detailed records that I would like to filter based on the selected date range. I want to have the bounds of the selected time range so I know what to filter on, and I would like to just have the domain change fire an event on the selection ending so as not to generate a bunch of frivolous data requests as the user adjusts their timeline selection. Some searching has found at least a couple of others with similar use cases.