### PR TITLE
Add RTL Support to Fix issue #825

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.scss
@@ -2,6 +2,10 @@
   float: left;
   overflow: visible;
 
+  [dir='rtl'] & {
+    direction: ltr;
+  }
+
   .circle,
   .bar,
   .arc {
@@ -110,5 +114,11 @@
         fill: rgba(0, 0, 0, 0.05);
       }
     }
+  }
+}
+
+.ngx-charts-outer {
+  [dir='rtl'] .advanced-pie & {
+    width: inherit !important;
   }
 }

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.scss
@@ -1,8 +1,13 @@
 .advanced-pie-legend {
   float: left;
   position: relative;
+
   top: 50%;
   transform: translate(0, -50%);
+  [dir='rtl'] & {
+    text-align: right;
+    float: right;
+  }
 
   .total-value {
     font-size: 36px;
@@ -24,6 +29,10 @@
         margin-right: 20px;
         display: inline-block;
         cursor: pointer;
+        [dir='rtl'] & {
+          margin-left: 20px;
+          margin-right: 0px;
+        }
 
         &:focus {
           outline: none;
@@ -40,12 +49,22 @@
           font-size: 24px;
           margin-top: -6px;
           margin-left: 11px;
+
+          [dir='rtl'] & {
+            margin-right: 11px;
+            margin-left: 0px;
+          }
         }
 
         .item-label {
           font-size: 14px;
           opacity: 0.7;
           margin-left: 11px;
+
+          [dir='rtl'] & {
+            margin-right: 11px;
+            margin-left: 0px;
+          }
           margin-top: -6px;
         }
 
@@ -53,6 +72,10 @@
           font-size: 24px;
           opacity: 0.7;
           margin-left: 11px;
+          [dir='rtl'] & {
+            margin-right: 11px;
+            margin-left: 0px;
+          }
         }
 
         .item-color {
@@ -61,6 +84,11 @@
           height: 42px;
           float: left;
           margin-right: 7px;
+          [dir='rtl'] & {
+            float: right;
+            margin-left: 7px;
+            margin-right: 0px;
+          }
         }
       }
     }

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -10,6 +10,10 @@
     margin-bottom: 5px;
     font-size: 14px;
     font-weight: bold;
+    [dir='rtl'] & {
+      margin-left: 0px;
+      margin-right: 10px;
+    }
   }
 
   ul,
@@ -40,6 +44,10 @@
     overflow-x: hidden;
     white-space: nowrap;
     background: rgba(0, 0, 0, 0.05);
+    [dir='rtl'] & {
+      float: right;
+      text-align: right;
+    }
   }
 
   .legend-label {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <main [class]="theme">
-  <div class="chart-col">
+  <div class="chart-col" [attr.dir]="dir">
     <div style="position: absolute; top: 50px; left: 50px; right: 50px; bottom: 50px;">
       <ngx-charts-bar-vertical
         *ngIf="chartType === 'bar-vertical'"
@@ -1117,6 +1117,12 @@
       <select [ngModel]="theme" (ngModelChange)="theme = $event">
         <option [value]="'dark'">Dark</option>
         <option [value]="'light'">Light</option>
+      </select>
+
+      <h3>Direction</h3>
+      <select [ngModel]="dir" (ngModelChange)="dir = $event">
+        <option [value]="'ltr'">Left to right</option>
+        <option [value]="'rtl'">Right to left</option>
       </select>
 
       <h3 (click)="dataVisible = !dataVisible" style="cursor: pointer;">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,6 +46,7 @@ export class AppComponent implements OnInit {
   APP_VERSION = version;
 
   theme = 'dark';
+  dir = 'ltr';
   chartType: string;
   chartGroups: any[];
   chart: any;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Charts would change and look wrong when dir=rtl is added to any parent HTML
Issue link: https://github.com/swimlane/ngx-charts/issues/825
![image](https://user-images.githubusercontent.com/13081893/89241568-9320d280-d5ff-11ea-95f5-c937ba935a77.png)



**What is the new behavior?**
Charts would keep their current format.
I did a quick research to understand how RTL language speakers use charts and found that the majority use axes that are LTR so I kept the axes and the drawings at LTR but instead only formatted the legends to be RTL and added a demo for it in the main app.
GIF of the demo switching between RTL and LTR:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/13081893/89242095-fc551580-d600-11ea-9884-2c58bdb7a67b.gif)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
