### PR TITLE
Feature/show sum in doughnut chart (resubmit from Zopo PR #1289 with fix)

### DIFF
--- a/docs/examples/pie-charts/pie-chart.md
+++ b/docs/examples/pie-charts/pie-chart.md
@@ -22,6 +22,7 @@
 | legendPosition  | string      | 'right'       | the legend position ['right', 'below']                                                                            |
 | explodeSlices   | boolean     | false         | make the radius of each slice proportional to it's value                                                          |
 | doughnut        | boolean     | false         | should doughnut instead of pie slices                                                                             |
+| showDoughnutSum | boolean     | false         | show or hide the sum of all values in the center of the doughnut chart                                            |
 | arcWidth        | number      | 0.25          | arc width, expressed as a fraction of outer radius                                                                |
 | gradient        | boolean     | false         | fill elements with a gradient instead of a solid color                                                            |
 | activeEntries   | object\[\]  | \[\]          | elements to highlight                                                                                             |

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.scss
@@ -15,6 +15,23 @@
   }
 }
 
+.doughnut-sum-label {
+  font-size: 16px;
+
+  &.animation {
+    animation: 750ms ease-in fadeIn;
+  
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+  }
+}
+
 .pie-label-line {
   stroke-dasharray: 100%;
 

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
@@ -44,6 +44,7 @@ import { DataItem } from '../models/chart-data.model';
           [tooltipDisabled]="tooltipDisabled"
           [tooltipTemplate]="tooltipTemplate"
           [tooltipText]="tooltipText"
+          [showSum]="doughnut && showDoughnutSum"
           (dblclick)="dblclick.emit($event)"
           (select)="onClick($event)"
           (activate)="onActivate($event)"
@@ -63,6 +64,7 @@ export class PieChartComponent extends BaseChartComponent {
   @Input() legendPosition: string = 'right';
   @Input() explodeSlices = false;
   @Input() doughnut = false;
+  @Input() showDoughnutSum = false;
   @Input() arcWidth = 0.25;
   @Input() gradient: boolean;
   @Input() activeEntries: any[] = [];

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
@@ -58,6 +58,9 @@ import { formatLabel, escapeLabel } from '../common/label.helper';
         [tooltipContext]="arc.data"
       ></svg:g>
     </svg:g>
+    <svg:text *ngIf="showSum" class="doughnut-sum-label" x="0" y="5" text-anchor="middle">
+      {{ sum() }}
+    </svg:text>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -78,6 +81,7 @@ export class PieSeriesComponent implements OnChanges {
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipTemplate: TemplateRef<any>;
   @Input() animations: boolean = true;
+  @Input() showSum: boolean = false;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -201,5 +205,14 @@ export class PieSeriesComponent implements OnChanges {
       return entry.name === d.name && entry.series === d.series;
     });
     return item !== undefined;
+  }
+
+  sum(): string {
+    let total = 0;
+    if (this.series != null && this.series.length > 0) {
+      total = this.series.reduce((sum, val) => sum += val.value, 0)
+    }
+
+    return formatLabel(total);
   }
 }

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
@@ -1,17 +1,23 @@
 import {
-  Component,
-  SimpleChanges,
-  Input,
-  Output,
-  EventEmitter,
-  OnChanges,
-  ChangeDetectionStrategy,
+  ChangeDetectionStrategy, Component,
+
+
+
+  EventEmitter, Input,
+
+
+  OnChanges, Output, SimpleChanges,
+
+
+
+
+
   TemplateRef
 } from '@angular/core';
 import { max } from 'd3-array';
 import { arc, pie } from 'd3-shape';
+import { escapeLabel, formatLabel } from '../common/label.helper';
 
-import { formatLabel, escapeLabel } from '../common/label.helper';
 
 @Component({
   selector: 'g[ngx-charts-pie-series]',
@@ -210,7 +216,7 @@ export class PieSeriesComponent implements OnChanges {
   sum(): string {
     let total = 0;
     if (this.series != null && this.series.length > 0) {
-      total = this.series.reduce((sum, val) => sum += val.value, 0)
+      total = this.series.reduce((sum, val) => sum += val.value, 0);
     }
 
     return formatLabel(total);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -305,6 +305,7 @@
         [explodeSlices]="explodeSlices"
         [labels]="showLabels"
         [doughnut]="doughnut"
+        [showDoughnutSum]="showDoughnutSum"
         [arcWidth]="arcWidth"
         (legendLabelClick)="onLegendLabelClick($event)"
         [gradient]="gradient"
@@ -1374,6 +1375,13 @@
           <label>
             <input type="checkbox" [checked]="doughnut" (change)="doughnut = $event.target.checked" />
             Doughnut
+          </label>
+          <br />
+        </div>
+        <div *ngIf="chart.options.includes('showDoughnutSum')">
+          <label>
+            <input type="checkbox" [checked]="showDoughnutSum" (change)="showDoughnutSum = $event.target.checked" />
+            Show Doughnut Sum
           </label>
           <br />
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -163,6 +163,7 @@ export class AppComponent implements OnInit {
   showLabels = true;
   explodeSlices = false;
   doughnut = false;
+  showDoughnutSum = false;
   arcWidth = 0.25;
 
   // line, area

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -297,6 +297,7 @@ const chartGroups = [
           'legendTitle',
           'legendPosition',
           'doughnut',
+          'showDoughnutSum',
           'arcWidth',
           'explodeSlices',
           'showLabels',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Doughnut charts have an empty hole in the middle


**What is the new behavior?**
Doughnut charts can be configured to show the sum of all values in the middle


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
- Fixed missing semi-colon causing ci failure in PR #1289 from Zopo.
Resolves: #1289, #874