### PR TITLE
Fix scale of timeline with mix and max specified

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
@@ -133,6 +133,8 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
         [customColors]="customColors"
         [legend]="legend"
         [scaleType]="scaleType"
+        [xScaleMin]="xScaleMin"
+        [xScaleMax]="xScaleMax"
         (onDomainChange)="updateDomain($event)"
       >
         <svg:g *ngFor="let series of results; trackBy: trackBy">

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
@@ -132,6 +132,8 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
         [customColors]="customColors"
         [legend]="legend"
         [scaleType]="scaleType"
+        [xScaleMin]="xScaleMin"
+        [xScaleMax]="xScaleMax"
         (onDomainChange)="updateDomain($event)"
       >
         <svg:g *ngFor="let series of results; trackBy: trackBy">

--- a/projects/swimlane/ngx-charts/src/lib/common/timeline/timeline.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/timeline/timeline.component.ts
@@ -47,6 +47,8 @@ export class Timeline implements OnChanges {
   @Input() miniChart;
   @Input() autoScale;
   @Input() scaleType;
+  @Input() xScaleMin: any;
+  @Input() xScaleMax: any;
   @Input() height: number = 50;
 
   @Output() select = new EventEmitter();
@@ -108,13 +110,13 @@ export class Timeline implements OnChanges {
 
     let domain = [];
     if (this.scaleType === 'time') {
-      const min = Math.min(...values);
-      const max = Math.max(...values);
+      const min = this.xScaleMin ? this.xScaleMin : Math.min(...values);
+      const max = this.xScaleMax ? this.xScaleMax : Math.max(...values);
       domain = [min, max];
     } else if (this.scaleType === 'linear') {
       values = values.map(v => Number(v));
-      const min = Math.min(...values);
-      const max = Math.max(...values);
+      const min = this.xScaleMin ? this.xScaleMin : Math.min(...values);
+      const max = this.xScaleMax ? this.xScaleMax : Math.max(...values);
       domain = [min, max];
     } else {
       domain = values;

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -136,6 +136,8 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
         [customColors]="customColors"
         [scaleType]="scaleType"
         [legend]="legend"
+        [xScaleMin]="xScaleMin"
+        [xScaleMax]="xScaleMax"
         (onDomainChange)="updateDomain($event)"
       >
         <svg:g *ngFor="let series of results; trackBy: trackBy">


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Timeline scale would not reflex min and max values. So timeline and actual chart would not be aligned when min and max are specified. For line chart, area chart and stacked area chart. Not for normalized area chart because this one does not support min and max xscale.
Fixes #1051
Fixes #1230

**What is the new behavior?**
Timeline scale correctly matches chart scale.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Tests: TOTAL: 48 SUCCESS
