### PR TITLE
Fix legend height is not included in the height calculation

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
@@ -15,7 +15,7 @@ import { TooltipService } from '../tooltip/tooltip.service';
   selector: 'ngx-charts-chart',
   template: `
     <div class="ngx-charts-outer" [style.width.px]="view[0]" [@animationState]="'active'" [@.disabled]="!animations">
-      <svg class="ngx-charts" [attr.width]="chartWidth" [attr.height]="view[1]">
+      <svg class="ngx-charts" [attr.width]="chartWidth" [attr.height]="chartHeight">
         <ng-content></ng-content>
       </svg>
       <ngx-charts-scale-legend
@@ -70,6 +70,7 @@ export class ChartComponent implements OnChanges {
   @Output() legendLabelDeactivate: EventEmitter<any> = new EventEmitter();
 
   chartWidth: any;
+  chartHeight: any;
   title: any;
   legendWidth: any;
 
@@ -79,6 +80,7 @@ export class ChartComponent implements OnChanges {
 
   update(): void {
     let legendColumns = 0;
+    this.chartHeight = this.view[1];
     if (this.showLegend) {
       this.legendType = this.getLegendType();
 
@@ -88,6 +90,8 @@ export class ChartComponent implements OnChanges {
         } else {
           legendColumns = 2;
         }
+      } else if (this.legendOptions && this.legendOptions.position === 'below') {
+        this.chartHeight = this.view[1] - 100;
       }
     }
 

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -40,6 +40,11 @@
     overflow-x: auto;
     overflow-y: hidden;
     margin-left: 10px;
+
+    &.legend-labels {
+      width: calc(100% - 10px);
+    }
+
     li {
       display: inline-block;
     }

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -19,12 +19,6 @@
     list-style: none;
   }
 
-  .horizontal-legend {
-    li {
-      display: inline-block;
-    }
-  }
-
   .legend-wrap {
     width: calc(100% - 10px);
   }
@@ -40,6 +34,15 @@
     overflow-x: hidden;
     white-space: nowrap;
     background: rgba(0, 0, 0, 0.05);
+  }
+
+  .horizontal-legend {
+    overflow-x: auto;
+    overflow-y: hidden;
+    margin-left: 10px;
+    li {
+      display: inline-block;
+    }
   }
 
   .legend-label {

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/scale-legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/scale-legend.component.scss
@@ -24,6 +24,8 @@
   .horizontal-legend {
     &.scale-legend {
       flex-direction: row;
+      margin-left: 0px;
+      padding: 0 10px;
     }
 
     .scale-legend-wrap {

--- a/projects/swimlane/ngx-charts/src/lib/common/view-dimensions.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/view-dimensions.helper.ts
@@ -23,11 +23,19 @@ export function calculateViewDimensions({
   let chartWidth = width;
   let chartHeight = height - margins[0] - margins[2];
 
-  if (showLegend && legendPosition === 'right') {
-    if (legendType === 'ordinal') {
-      columns -= 2;
-    } else {
-      columns -= 1;
+  if (showLegend) {
+    if (legendPosition === 'right') {
+      if (legendType === 'ordinal') {
+        columns -= 2;
+      } else {
+        columns -= 1;
+      }
+    } else if (legendPosition === 'below') {
+      if (legendType === 'ordinal') {
+        chartHeight -= 100;
+      } else {
+        chartHeight -= 50;
+      }
     }
   }
 

--- a/projects/swimlane/ngx-charts/src/lib/common/view-dimensions.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/view-dimensions.helper.ts
@@ -31,11 +31,7 @@ export function calculateViewDimensions({
         columns -= 1;
       }
     } else if (legendPosition === 'below') {
-      if (legendType === 'ordinal') {
-        chartHeight -= 100;
-      } else {
-        chartHeight -= 50;
-      }
+      chartHeight -= 100;
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When a chart is placed inside a parent div with fixed height and set legendPosition="below", view=null (fit container). The legend is placed outside of the parent div.

An example can be found [here](https://stackblitz.com/edit/swimlane-stacked-vertical-bar-chart-zbvjhd)
Or some open issues:
https://github.com/swimlane/ngx-charts/issues/1424
https://github.com/swimlane/ngx-charts/issues/1248
**What is the new behavior?**
The legend is now placed within the parent div.

Bar chart:
![image](https://user-images.githubusercontent.com/19187875/94778991-86570a00-0409-11eb-9df9-dd0126c50580.png)
Pie chart:
![image](https://user-images.githubusercontent.com/19187875/94779031-94a52600-0409-11eb-9bb4-a52071412016.png)
Bubble chart:
![image](https://user-images.githubusercontent.com/19187875/94779095-b1415e00-0409-11eb-8136-d8c6ba4a041f.png)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
some small style changes when placed below: give some space on the left and right side of the legend.
make the legend scrollable when the legend is placed below but doesn't have enough space to show.
![image](https://user-images.githubusercontent.com/19187875/94779471-59572700-040a-11eb-8e14-c0c602b6c257.png)
