### PR TITLE
add gauge range feature

### DIFF
--- a/docs/examples/gauge-chart.md
+++ b/docs/examples/gauge-chart.md
@@ -50,6 +50,14 @@ The data format is single series:
   {
     "name": "USA",
     "value": 5000000
+  },
+  {
+    "name": "China",
+    "value": 4000000,
+    "extra": 
+    {
+      "startValue": 20000000 // this will create a range arc
+    }
   }
 ]
 ```

--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge-arc.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge-arc.component.ts
@@ -19,7 +19,7 @@ import { ColorHelper } from '../common/color.helper';
     ></svg:g>
     <svg:g
       ngx-charts-pie-arc
-      [startAngle]="0"
+      [startAngle]="valueArc.startAngle"
       [endAngle]="valueArc.endAngle"
       [innerRadius]="valueArc.innerRadius"
       [outerRadius]="valueArc.outerRadius"

--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
@@ -208,6 +208,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
 
       const valueArc = {
         endAngle: (Math.min(this.valueScale(d.value), this.angleSpan) * Math.PI) / 180,
+        startAngle: (Math.min(this.valueScale(d.extra?.startValue ?? this.min), this.angleSpan) * Math.PI) / 180,
         innerRadius,
         outerRadius,
         data: {

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -26,6 +26,7 @@ export const single: SingleSeries = [
     name: 'France',
     value: 36745,
     extra: {
+      startValue: 50000,
       code: 'fr'
     }
   },
@@ -40,6 +41,7 @@ export const single: SingleSeries = [
     name: 'Spain',
     value: 33000,
     extra: {
+      startValue: 20000,
       code: 'es'
     }
   },
@@ -47,6 +49,7 @@ export const single: SingleSeries = [
     name: 'Italy',
     value: 35800,
     extra: {
+      startValue: 150000,
       code: 'it'
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
currently all gauge arcs start at the min value provided by the results array.
#1527 

**What is the new behavior?**
we can now display range arcs which will start at an optionally provided `startValue` and defaults to the `min` value.
The new data format looks like this:
```
[
  {
    name: 'France',
    value: 36745,
    extra: {
      startValue: 20000,
      code: 'fr'
    }
  }.
  ...
]
```


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
![image](https://user-images.githubusercontent.com/33879057/95574114-bf583580-0a2c-11eb-94ae-4f9c80e05c77.png)

