### PR TITLE
If yScale attribute is using, it sets the right and left maxima with …

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -598,6 +598,7 @@
         [yAxisLabelRight]="yAxisLabelRight"
         [noBarWhenZero]="noBarWhenZero"
         (select)="onSelect($event)"
+        [yScaleMax]="yScaleMaxCombo"
       >
       </combo-chart-component>
       <ngx-charts-heat-map

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -212,6 +212,7 @@ export class AppComponent implements OnInit {
 
   showRightYAxisLabel: boolean = true;
   yAxisLabelRight: string = 'Utilization';
+  yScaleMaxCombo = 0 ;
 
   // demos
   totalSales = 0;

--- a/src/app/custom-charts/combo-chart/combo-chart.component.ts
+++ b/src/app/custom-charts/combo-chart/combo-chart.component.ts
@@ -57,6 +57,7 @@ export class ComboChartComponent extends BaseChartComponent {
   @Input() rangeFillOpacity: number;
   @Input() animations: boolean = true;
   @Input() noBarWhenZero: boolean = true;
+  @Input() yScaleMax;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -262,13 +263,13 @@ export class ComboChartComponent extends BaseChartComponent {
     }
 
     let min = Math.min(...domain);
-    const max = Math.max(...domain);
+    const max = this.yScaleMax ? this.yScaleMax : Math.max(...domain);
     if (this.yRightAxisScaleFactor) {
       const minMax = this.yRightAxisScaleFactor(min, max);
       return [Math.min(0, minMax.min), minMax.max];
     } else {
       min = Math.min(0, min);
-      return [min, max];
+      return [min, this.yScaleMax ? this.yScaleMax : max];
     }
   }
 
@@ -321,7 +322,7 @@ export class ComboChartComponent extends BaseChartComponent {
   getYDomain() {
     const values = this.results.map(d => d.value);
     const min = Math.min(0, ...values);
-    const max = Math.max(...values);
+    const max =this.yScaleMax? this.yScaleMax : Math.max(...values);
     if (this.yLeftAxisScaleFactor) {
       const minMax = this.yLeftAxisScaleFactor(min, max);
       return [Math.min(0, minMax.min), minMax.max];


### PR DESCRIPTION
Although it has x attributes, the same scale label values are not shown at the moment.

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Although it has x attributes, the same scale label values are not shown at the moment.
https://github.com/swimlane/ngx-charts/issues/1532


**What is the new behavior?**
If yScale attribute is using, it sets the right and left maxima with respect to yScale attribute. If not defined, the left and right scales are adjusted according to their maximum value.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
