### PR TITLE
(feat): send index to formatting functions

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis-ticks.component.ts
@@ -17,15 +17,15 @@ import { reduceTicks } from './ticks.helper';
   selector: 'g[ngx-charts-x-axis-ticks]',
   template: `
     <svg:g #ticksel>
-      <svg:g *ngFor="let tick of ticks" class="tick" [attr.transform]="tickTransform(tick)">
-        <title>{{ tickFormat(tick) }}</title>
+      <svg:g *ngFor="let tick of ticks; let i = index" class="tick" [attr.transform]="tickTransform(tick)">
+        <title>{{ tickFormat(tick, i) }}</title>
         <svg:text
           stroke-width="0.01"
           [attr.text-anchor]="textAnchor"
           [attr.transform]="textTransform"
           [style.font-size]="'12px'"
         >
-          {{ tickTrim(tickFormat(tick)) }}
+          {{ tickTrim(tickFormat(tick, i)) }}
         </svg:text>
       </svg:g>
     </svg:g>
@@ -65,7 +65,7 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   adjustedScale: any;
   textTransform: any;
   ticks: any;
-  tickFormat: (o: any) => any;
+  tickFormat: (o: any, index: number) => any;
   height: number = 0;
 
   @ViewChild('ticksel') ticksElement: ElementRef;
@@ -128,7 +128,7 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
     let angle = 0;
     this.maxTicksLength = 0;
     for (let i = 0; i < ticks.length; i++) {
-      const tick = this.tickFormat(ticks[i]).toString();
+      const tick = this.tickFormat(ticks[i], i).toString();
       let tickLength = tick.length;
       if (this.trimTicks) {
         tickLength = this.tickTrim(tick).length;

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
@@ -18,8 +18,8 @@ import { roundedRect } from '../../common/shape.helper';
   selector: 'g[ngx-charts-y-axis-ticks]',
   template: `
     <svg:g #ticksel>
-      <svg:g *ngFor="let tick of ticks" class="tick" [attr.transform]="transform(tick)">
-        <title>{{ tickFormat(tick) }}</title>
+      <svg:g *ngFor="let tick of ticks; let i = index" class="tick" [attr.transform]="transform(tick)">
+        <title>{{ tickFormat(tick, i) }}</title>
         <svg:text
           stroke-width="0.01"
           [attr.dy]="dy"
@@ -28,7 +28,7 @@ import { roundedRect } from '../../common/shape.helper';
           [attr.text-anchor]="textAnchor"
           [style.font-size]="'12px'"
         >
-          {{ tickTrim(tickFormat(tick)) }}
+          {{ tickTrim(tickFormat(tick, i)) }}
         </svg:text>
       </svg:g>
     </svg:g>
@@ -56,7 +56,7 @@ import { roundedRect } from '../../common/shape.helper';
       </svg:g>
     </svg:g>
 
-    <svg:g *ngFor="let refLine of referenceLines">
+    <svg:g *ngFor="let refLine of referenceLines; let i = index">
       <svg:g *ngIf="showRefLines" [attr.transform]="transform(refLine.value)">
         <svg:line
           class="refline-path gridline-path-horizontal"
@@ -65,7 +65,7 @@ import { roundedRect } from '../../common/shape.helper';
           [attr.transform]="gridLineTransform()"
         />
         <svg:g *ngIf="showRefLabels">
-          <title>{{ tickTrim(tickFormat(refLine.value)) }}</title>
+          <title>{{ tickTrim(tickFormat(refLine.value, i)) }}</title>
           <svg:text
             class="refline-label"
             [attr.dy]="dy"
@@ -111,7 +111,7 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   y2: any;
   adjustedScale: any;
   transform: (o: any) => string;
-  tickFormat: (o: any) => string;
+  tickFormat: (o: any, index: number) => string;
   ticks: any;
   width: number = 0;
   outerTickSize: number = 6;

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
@@ -16,14 +16,14 @@ import { formatLabel, escapeLabel } from '../common/label.helper';
 @Component({
   selector: 'g[ngx-charts-pie-series]',
   template: `
-    <svg:g *ngFor="let arc of data; trackBy: trackBy">
+    <svg:g *ngFor="let arc of data; trackBy: trackBy; let i = index">
       <svg:g
         ngx-charts-pie-label
         *ngIf="labelVisible(arc)"
         [data]="arc"
         [radius]="outerRadius"
         [color]="color(arc)"
-        [label]="labelText(arc)"
+        [label]="labelText(arc, i)"
         [labelTrim]="trimLabels"
         [labelTrimSize]="maxLabelLength"
         [max]="max"
@@ -162,9 +162,9 @@ export class PieSeriesComponent implements OnChanges {
     return this.tooltipTemplate ? undefined : this.tooltipText(a);
   }
 
-  labelText(myArc): string {
+  labelText(myArc, index: number): string {
     if (this.labelFormatting) {
-      return this.labelFormatting(myArc.data.name);
+      return this.labelFormatting(myArc.data.name, index);
     }
     return this.label(myArc);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In formatting functions (`labelFormatting`, `xAxisTickFormatting`, `yAxisTickFormatting`) only the text is sending, and you can't use value or any other data to format. There is the related issue #1549 


**What is the new behavior?**
I added a second param to this functions with the index, and now you can get the rest of the data that you need. This change doesn't affect if you don't use it


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
For example, now you can use the index like this
```ts
labelFormatting = (label: string, index: number): string => {
  console.log(label, index);
  // 'This is the label', 0
  return `${this.decimalPipe.transform(this.data[index].value, '1.0-2')}: ${label}`;
};
```
