### PR TITLE
added placement.type in public-api.ts

### DIFF
--- a/projects/swimlane/ngx-charts/src/public-api.ts
+++ b/projects/swimlane/ngx-charts/src/public-api.ts
@@ -42,6 +42,7 @@ export * from './lib/common/tooltip/tooltip.directive';
 export * from './lib/common/tooltip/style.type';
 export * from './lib/common/tooltip/alignment.type';
 export * from './lib/common/tooltip/show.type';
+export * from './lib/common/tooltip/position/placement.type';
 
 export * from './lib/common/axes/axes.module';
 export * from './lib/common/axes/axis-label.component';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe:

missing api import:
export * from './lib/common/tooltip/position/placement.type';

**What is the current behavior?** (You can also link to an open issue here)

can't import PlacementTypes from tooltip position in order to use it in a combo chart with typescript strict checking enabled

**What is the new behavior?**

you can import PlacementTypes


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
