### PR TITLE
(feat): Custom legend entry (#1337)

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-normalized.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-normalized.component.ts
@@ -25,6 +25,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -190,6 +191,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
   @ContentChild('seriesTooltipTemplate') seriesTooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   scaleType: string;

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
@@ -25,6 +25,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -193,6 +194,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
   @ContentChild('seriesTooltipTemplate') seriesTooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   scaleType: string;

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
@@ -25,6 +25,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -195,6 +196,7 @@ export class AreaChartComponent extends BaseChartComponent {
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
   @ContentChild('seriesTooltipTemplate') seriesTooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   xSet: any;

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-2d.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-2d.component.ts
@@ -23,6 +23,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -150,6 +151,7 @@ export class BarHorizontal2DComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-normalized.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-normalized.component.ts
@@ -23,6 +23,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -133,6 +134,7 @@ export class BarHorizontalNormalizedComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal-stacked.component.ts
@@ -23,6 +23,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -140,6 +141,7 @@ export class BarHorizontalStackedComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal.component.ts
@@ -21,6 +21,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -122,6 +123,7 @@ export class BarHorizontalComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   yScale: any;

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
@@ -22,6 +22,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -147,6 +148,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-normalized.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-normalized.component.ts
@@ -22,6 +22,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -132,6 +133,7 @@ export class BarVerticalNormalizedComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
@@ -22,6 +22,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, undefined, true)"
@@ -139,6 +140,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   groupDomain: any[];

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical.component.ts
@@ -22,6 +22,7 @@ import { DataItem } from '../models/chart-data.model';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -123,6 +124,7 @@ export class BarVerticalComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   xScale: any;

--- a/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.component.ts
@@ -27,6 +27,7 @@ import { id } from '../utils/id';
       [showLegend]="legend"
       [activeEntries]="activeEntries"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
       (legendLabelActivate)="onActivate($event)"
@@ -159,6 +160,7 @@ export class BubbleChartComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   colors: ColorHelper;

--- a/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
@@ -5,7 +5,8 @@ import {
   ChangeDetectionStrategy,
   EventEmitter,
   Output,
-  SimpleChanges
+  SimpleChanges,
+  TemplateRef
 } from '@angular/core';
 import { trigger, style, animate, transition } from '@angular/animations';
 import { TooltipService } from '../tooltip/tooltip.service';
@@ -38,6 +39,7 @@ import { TooltipService } from '../tooltip/tooltip.service';
         [height]="view[1]"
         [width]="legendWidth"
         [activeEntries]="activeEntries"
+        [legendEntryTemplate]="legendEntryTemplate"
         (labelClick)="legendLabelClick.emit($event)"
         (labelActivate)="legendLabelActivate.emit($event)"
         (labelDeactivate)="legendLabelDeactivate.emit($event)"
@@ -64,6 +66,7 @@ export class ChartComponent implements OnChanges {
   @Input() colors: any;
   @Input() activeEntries: any[];
   @Input() animations: boolean = true;
+  @Input() legendEntryTemplate: TemplateRef<any>;
 
   @Output() legendLabelClick: EventEmitter<any> = new EventEmitter();
   @Output() legendLabelActivate: EventEmitter<any> = new EventEmitter();

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend-entry.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend-entry.component.ts
@@ -1,14 +1,19 @@
-import { Component, Input, Output, ChangeDetectionStrategy, HostListener, EventEmitter } from '@angular/core';
+import { Component, Input, Output, ChangeDetectionStrategy, HostListener, EventEmitter, TemplateRef } from '@angular/core';
 
 @Component({
   selector: 'ngx-charts-legend-entry',
   template: `
-    <span [title]="formattedLabel" tabindex="-1" [class.active]="isActive" (click)="select.emit(formattedLabel)">
+    <ng-container *ngIf="legendEntryTemplate">
+      <ng-container *ngTemplateOutlet="legendEntryTemplate;context:{label:label,color:color}"></ng-container>
+    </ng-container>
+    <ng-container *ngIf="!legendEntryTemplate">
+      <span [title]="formattedLabel" tabindex="-1" [class.active]="isActive" (click)="select.emit(formattedLabel)">
       <span class="legend-label-color" [style.background-color]="color" (click)="toggle.emit(formattedLabel)"> </span>
       <span class="legend-label-text">
         {{ trimmedLabel }}
       </span>
     </span>
+    </ng-container>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -17,6 +22,7 @@ export class LegendEntryComponent {
   @Input() label: any;
   @Input() formattedLabel: string;
   @Input() isActive: boolean = false;
+  @Input() legendEntryTemplate: TemplateRef<any>;
 
   @Output() select: EventEmitter<any> = new EventEmitter();
   @Output() activate: EventEmitter<any> = new EventEmitter();

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.ts
@@ -7,9 +7,10 @@ import {
   SimpleChanges,
   OnChanges,
   ChangeDetectorRef,
-  ViewEncapsulation
+  ViewEncapsulation,
+  TemplateRef
 } from '@angular/core';
-import { formatLabel } from '../label.helper';
+import {formatLabel} from '../label.helper';
 
 @Component({
   selector: 'ngx-charts-legend',
@@ -24,6 +25,7 @@ import { formatLabel } from '../label.helper';
             <ngx-charts-legend-entry
               [label]="entry.label"
               [formattedLabel]="entry.formattedLabel"
+              [legendEntryTemplate]="legendEntryTemplate"
               [color]="entry.color"
               [isActive]="isActive(entry)"
               (select)="labelClick.emit($event)"
@@ -48,6 +50,7 @@ export class LegendComponent implements OnChanges {
   @Input() width;
   @Input() activeEntries;
   @Input() horizontal = false;
+  @Input() legendEntryTemplate: TemplateRef<any>;
 
   @Output() labelClick: EventEmitter<any> = new EventEmitter();
   @Output() labelActivate: EventEmitter<any> = new EventEmitter();
@@ -55,7 +58,8 @@ export class LegendComponent implements OnChanges {
 
   legendEntries: any[] = [];
 
-  constructor(private cd: ChangeDetectorRef) {}
+  constructor(private cd: ChangeDetectorRef) {
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     this.update();

--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
@@ -24,6 +24,7 @@ import { ColorHelper } from '../common/color.helper';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -107,6 +108,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   @ViewChild('textEl') textEl: ElementRef;
 

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -26,6 +26,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -215,6 +216,7 @@ export class LineChartComponent extends BaseChartComponent {
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
   @ContentChild('seriesTooltipTemplate') seriesTooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   xSet: any;

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
@@ -20,6 +20,7 @@ import { DataItem } from '../models/chart-data.model';
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelActivate)="onActivate($event, true)"
@@ -79,6 +80,7 @@ export class PieChartComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   translation: string;
   outerRadius: number;

--- a/projects/swimlane/ngx-charts/src/lib/polar-chart/polar-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/polar-chart/polar-chart.component.ts
@@ -27,6 +27,7 @@ const twoPI = 2 * Math.PI;
       [view]="[width, height]"
       [showLegend]="legend"
       [legendOptions]="legendOptions"
+      [legendEntryTemplate]="legendEntryTemplate"
       [activeEntries]="activeEntries"
       [animations]="animations"
       (legendLabelClick)="onClick($event)"
@@ -164,6 +165,7 @@ export class PolarChartComponent extends BaseChartComponent {
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+  @ContentChild('legendEntryTemplate') legendEntryTemplate: TemplateRef<any>;
 
   dims: ViewDimensions;
   yAxisDims: ViewDimensions;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently there is no way to customize the entries in the legend (see issue #1337)


**What is the new behavior?**
Now is possible to define a `legendEntryTemplate` as a child of the component (similarly to the `tooltipTemplate`). The template exposes `color` and `label` as parameters. `legendEntryTemplate` is available for the following components:

`polar-chart`
`line-chart`
`pie-chart`
`gauge`
`bubble-chart`
`bar-chart`
`area-chart`

Here's an example of usage

```html
      <ngx-charts-pie-chart
        *ngIf="chartType === 'pie-chart'"
        class="chart-container"
        [view]="view"
        [scheme]="colorScheme"
        [results]="single"
        [animations]="animations"
        [legend]="showLegend"
        [legendTitle]="legendTitle"
        [legendPosition]="legendPosition"
        [explodeSlices]="explodeSlices"
        [labels]="showLabels"
        [doughnut]="doughnut"
        [arcWidth]="arcWidth"
        (legendLabelClick)="onLegendLabelClick($event)"
        [gradient]="gradient"
        [tooltipDisabled]="tooltipDisabled"
        [tooltipText]="pieTooltipText"
        (dblclick)="dblclick($event)"
        (select)="select($event)"
        (activate)="activate($event)"
        (deactivate)="deactivate($event)"
      >
        <ng-template #legendEntryTemplate let-color="color" let-label="label">
          <span [style]="'color: ' + color">{{label}}</span>
        </ng-template>
      </ngx-charts-pie-chart>
```

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
