### PR TITLE
Calculate vertical group spacing based on chart width, not chart height

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
@@ -217,7 +217,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   }
 
   getGroupScale(): any {
-    const spacing = this.groupDomain.length / (this.dims.height / this.groupPadding + 1);
+    const spacing = this.groupDomain.length / (this.dims.width / this.groupPadding + 1);
 
     return scaleBand()
       .rangeRound([0, this.dims.width])


### PR DESCRIPTION
Fixes/Improves behavior of #786 

To me it makes sense to calculate group spacing on chart width and not chart height in a vertical grouped bar chart. I think this may be a copy paste from the horizontal grouped bar chart?

**What kind of change does this PR introduce?** 
- Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Groups gets incorrect spacing for beyond a certain group/chart_width ratio and the result is that bars are placed on top of each other:
![image](https://user-images.githubusercontent.com/22211891/107495666-ab664100-6b90-11eb-8feb-1bed3b14ceff.png)

**What is the new behavior?**
Groups get correct spacing calculated based on width of chart instead of the height of the chart:
![image](https://user-images.githubusercontent.com/22211891/107495731-c1740180-6b90-11eb-8c0f-8ea0e594dcf3.png)

**Does this PR introduce a breaking change?** 
- No
