### PR TITLE
Generating unique ids without memory leaks

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/utils/id.ts
+++ b/projects/swimlane/ngx-charts/src/lib/utils/id.ts
@@ -1,26 +1,51 @@
-const cache = {};
+// js uses only double-precision arithmetic, and truncation
+// (e.g. operator '~~') is not reliable above 2^31-1 as it
+// treats the number as signed, while a Linear Congruential
+// Generator works on unsigned arithmetic. A double has a
+// mantissa of 52 bits, so we need to stay in the interval
+// [0, 2^52) if we don't want to loose precision.
+const m = 2 ** 21;
+const a = 214013;
+const c = 2531011;
+
+// The choice of these parameters reflects this thought.
+// During computation, the maximum state value is (m - 1):
+// for this reason, the highest value we are computing is
+// (m - 1) * a + c.
+// In this case, 448820107974 < 2^39.
+let x = +(new Date());
+
+function lcg_next(): number {
+  // Max value here is
+  // (m - 1) * a + c
+  x = (a * x + c) % m;
+  return x;
+}
+
+const MAX_ID = 36 ** 4;
 
 /**
  * Generates a short id.
  *
  * Description:
- *   A 4-character alphanumeric sequence (364 = 1.6 million)
+ *   A 4-character alphanumeric sequence (36^4 = 1.6 million)
  *   This should only be used for JavaScript specific models.
- *   http://stackoverflow.com/questions/6248666/how-to-generate-short-uid-like-ax4j9z-in-js
- *
- *   Example: `ebgf`
+ *   https://en.wikipedia.org/wiki/Linear_congruential_generator
+ * 
+ *   The random 4-character string is prefixed with an 'a'.
+ * 
+ *   Example: `aebgf`
  */
 export function id(): string {
-  let newId = ('0000' + ((Math.random() * Math.pow(36, 4)) << 0).toString(36)).slice(-4);
+  // lcg_next outputs a 21-bit result, giving us a 4-5 character id
+  // (since 2^21 is slightly higher than 36^4).
+  // Given that we don't want ids with 5 character, if we don't want
+  // duplicates in the rage, we must discard values above 36^4.
+  let newId: number;
+  do {
+    newId = lcg_next();
+  } while (newId >= MAX_ID);
 
   // append a 'a' because neo gets mad
-  newId = `a${newId}`;
-
-  // ensure not already used
-  if (!cache[newId]) {
-    cache[newId] = true;
-    return newId;
-  }
-
-  return id();
+  return `a${newId.toString(36)}`;
 }


### PR DESCRIPTION
The id() function now uses a Linear Congruential Generator with a 21-bit
period so that it generates pseudo-random numbers without duplicates,
without the need of a cache holding already used values.

Given the 4-digit mantissa of this method, after around 1.6 milion ids
it will start to generate duplicates consistently, but it is still
better than a stack-overflow as the old implementation (which, by the
way came much before reaching the 1.6 milion limit).

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#1310


**What is the new behavior?**
No memory-leak, no stack overflow during usage, and it should be faster *on average*.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
