### PR TITLE
Forward timeline selection

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-normalized.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-normalized.component.ts
@@ -390,6 +390,7 @@ export class AreaChartNormalizedComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomain = this.filteredDomain;
     this.xScale = this.getXScale(this.xDomain, this.dims.width);
+    this.timelineSelectionChanged.emit(domain);
   }
 
   updateHoveredVertical(item): void {

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
@@ -405,6 +405,7 @@ export class AreaChartStackedComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomain = this.filteredDomain;
     this.xScale = this.getXScale(this.xDomain, this.dims.width);
+    this.timelineSelectionChanged.emit(domain);
   }
 
   updateHoveredVertical(item) {

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
@@ -397,6 +397,7 @@ export class AreaChartComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomain = this.filteredDomain;
     this.xScale = this.getXScale(this.xDomain, this.dims.width);
+    this.timelineSelectionChanged.emit(domain);
   }
 
   updateHoveredVertical(item): void {

--- a/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.ts
@@ -34,6 +34,7 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
   @Input() animations: boolean = true;
 
   @Output() select = new EventEmitter();
+  @Output() timelineSelectionChanged = new EventEmitter();
 
   width: number;
   height: number;

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -404,6 +404,7 @@ export class LineChartComponent extends BaseChartComponent {
     this.filteredDomain = domain;
     this.xDomain = this.filteredDomain;
     this.xScale = this.getXScale(this.xDomain, this.dims.width);
+    this.timelineSelectionChanged.emit(domain);
   }
 
   updateHoveredVertical(item): void {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -386,6 +386,7 @@
         (select)="select($event)"
         (activate)="activate($event)"
         (deactivate)="deactivate($event)"
+        (timelineSelectionChanged)="onTimelineSelectionChange($event)"
       >
       </ngx-charts-line-chart>
       <ngx-charts-polar-chart
@@ -495,6 +496,7 @@
         (select)="select($event)"
         (activate)="activate($event)"
         (deactivate)="deactivate($event)"
+        (timelineSelectionChanged)="onTimelineSelectionChange($event)"
       >
       </ngx-charts-area-chart>
       <ngx-charts-area-chart-stacked
@@ -533,6 +535,7 @@
         (select)="select($event)"
         (activate)="activate($event)"
         (deactivate)="deactivate($event)"
+        (timelineSelectionChanged)="onTimelineSelectionChange($event)"
       >
       </ngx-charts-area-chart-stacked>
       <ngx-charts-area-chart-normalized
@@ -567,6 +570,7 @@
         (select)="select($event)"
         (activate)="activate($event)"
         (deactivate)="deactivate($event)"
+        (timelineSelectionChanged)="onTimelineSelectionChange($event)"
       >
       </ngx-charts-area-chart-normalized>
       <combo-chart-component

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -773,4 +773,8 @@ export class AppComponent implements OnInit {
     this.bubbleDemoChart.drilldown(event);
     this.bubbleDemoTempData = this.bubbleDemoChart.toChart();
   }
+
+  onTimelineSelectionChange(domain) {
+    console.log(domain);
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Timeline selection is only accessible inside the ngx-charts components. 
Fixes #1327

**What is the new behavior?**
Forward the selected domain of the timeline of line, area, stacked area and normalized chart.
Output property "timelineSelectionChanged" is defined in BaseChartComponent.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
