### PR TITLE
Fix to make zero a valid min/max value for axis limit

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart-stacked.component.ts
@@ -319,9 +319,9 @@ export class AreaChartStackedComponent extends BaseChartComponent {
     let min;
     let max;
     if (this.scaleType === ScaleType.Time || this.scaleType === ScaleType.Linear) {
-      min = this.xScaleMin ? this.xScaleMin : Math.min(...values);
+      min = this.xScaleMin == null ? Math.min(...values) : this.xScaleMin;
 
-      max = this.xScaleMax ? this.xScaleMax : Math.max(...values);
+      max = this.xScaleMax == null ? Math.max(...values) : this.xScaleMax;
     }
 
     if (this.scaleType === ScaleType.Time) {
@@ -370,9 +370,9 @@ export class AreaChartStackedComponent extends BaseChartComponent {
       domain.push(sum);
     }
 
-    const min = this.yScaleMin ? this.yScaleMin : Math.min(0, ...domain);
+    const min = this.yScaleMin == null ? Math.min(0, ...domain) : this.yScaleMin;
 
-    const max = this.yScaleMax ? this.yScaleMax : Math.max(...domain);
+    const max = this.yScaleMax == null ? Math.max(...domain) : this.yScaleMax;
     return [min, max];
   }
 

--- a/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/area-chart/area-chart.component.ts
@@ -293,9 +293,9 @@ export class AreaChartComponent extends BaseChartComponent {
     let min;
     let max;
     if (this.scaleType === ScaleType.Time || this.scaleType === ScaleType.Linear) {
-      min = this.xScaleMin ? this.xScaleMin : Math.min(...values);
+      min = this.xScaleMin == null ? Math.min(...values) : this.xScaleMin;
 
-      max = this.xScaleMax ? this.xScaleMax : Math.max(...values);
+      max = this.xScaleMax == null ? Math.max(...values) : this.xScaleMax;
     }
 
     if (this.scaleType === ScaleType.Time) {
@@ -338,9 +338,9 @@ export class AreaChartComponent extends BaseChartComponent {
       values.push(this.baseValue);
     }
 
-    const min = this.yScaleMin ? this.yScaleMin : Math.min(...values);
+    const min = this.yScaleMin == null ? Math.min(...values) : this.yScaleMin;
 
-    const max = this.yScaleMax ? this.yScaleMax : Math.max(...values);
+    const max = this.yScaleMax == null ? Math.max(...values) : this.yScaleMax;
 
     return [min, max];
   }

--- a/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.utils.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.utils.ts
@@ -17,8 +17,8 @@ export function getDomain(
   }
 
   if (scaleType === ScaleType.Time || scaleType === ScaleType.Linear) {
-    const min = minVal ? minVal : Math.min(...values);
-    const max = maxVal ? maxVal : Math.max(...values);
+    const min = minVal == null ? Math.min(...values) : minVal;
+    const max = maxVal == null ? Math.max(...values) : maxVal;
 
     domain = [min, max];
   } else {

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -312,9 +312,9 @@ export class LineChartComponent extends BaseChartComponent {
     let min;
     let max;
     if (this.scaleType === ScaleType.Time || this.scaleType === ScaleType.Linear) {
-      min = this.xScaleMin ? this.xScaleMin : Math.min(...values);
+      min = this.xScaleMin == null ? Math.min(...values) : this.xScaleMin;
 
-      max = this.xScaleMax ? this.xScaleMax : Math.max(...values);
+      max = this.xScaleMax == null ? Math.max(...values) : this.xScaleMax;
     }
 
     if (this.scaleType === ScaleType.Time) {
@@ -365,9 +365,9 @@ export class LineChartComponent extends BaseChartComponent {
       values.push(0);
     }
 
-    const min = this.yScaleMin ? this.yScaleMin : Math.min(...values);
+    const min = this.yScaleMin == null ? Math.min(...values) : this.yScaleMin;
 
-    const max = this.yScaleMax ? this.yScaleMax : Math.max(...values);
+    const max = this.yScaleMax == null ? Math.max(...values) : this.yScaleMax;
 
     return [min, max];
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Zero can't be used as min or max value for x or y axis (line, area, stacked area and bubble chart).


**What is the new behavior?**
Condition check by comparing with "null" instead direct compare to catch the value "0".
Using normal equal operator to catch "null" and "undefined".


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
