### PR TITLE
Importable Type for BarOrientation

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar.component.ts
@@ -13,15 +13,11 @@ import { select } from 'd3-selection';
 import { roundedRect } from '../common/shape.helper';
 import { id } from '../utils/id';
 import { Gradient } from '../common/types';
+import { BarOrientation } from '../common/types/bar-orientation';
 import { DataItem } from '../models/chart-data.model';
 
 /* tslint:disable-next-line */
 import { transition } from 'd3-transition';
-
-enum BarOrientation {
-  Vertical = 'vertical',
-  Horizontal = 'horizontal'
-}
 
 @Component({
   selector: 'g[ngx-charts-bar]',

--- a/projects/swimlane/ngx-charts/src/lib/common/types/bar-orientation.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/types/bar-orientation.ts
@@ -1,0 +1,4 @@
+export enum BarOrientation {
+  Vertical = 'vertical',
+  Horizontal = 'horizontal'
+}


### PR DESCRIPTION
When using Template strict it is required to have a type.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

When using a project with strict template check. There will be an error if using barOrientation. The lack of an exposed Type causes not being to build with strict template.

**What is the current behavior?** (You can also link to an open issue here)

enum BarOrientation is private inside BarComponent

**What is the new behavior?**

BarOrientation is now exported

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
