### PR TITLE
Fixes #1562 #1165 #1158 #1062 #808 #672

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
@@ -41,7 +41,7 @@ export class AreaComponent implements OnChanges {
   gradientId: string;
   gradientFill: string;
   areaPath: string;
-  initialized: boolean = false;
+  animationsLoaded: boolean = false;
   gradientStops: Gradient[];
   hasGradient: boolean = false;
 
@@ -50,11 +50,11 @@ export class AreaComponent implements OnChanges {
   }
 
   ngOnChanges(): void {
-    if (!this.initialized) {
+    this.update();
+
+    if (!this.animationsLoaded) {
       this.loadAnimation();
-      this.initialized = true;
-    } else {
-      this.update();
+      this.animationsLoaded = true;
     }
   }
 
@@ -74,7 +74,7 @@ export class AreaComponent implements OnChanges {
 
   loadAnimation(): void {
     this.areaPath = this.startingPath;
-    setTimeout(this.update.bind(this), 100);
+    setTimeout(this.updatePathEl.bind(this), 100);
   }
 
   updatePathEl(): void {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Line charts display a gray solid fill instead of a colored gradient when additional series are added to the input "results" as shown in #1158 and demonstrated by this [stackblitz](https://stackblitz.com/edit/ngx-charts-line-chart-bug?file=src/app/app.component.ts).

https://user-images.githubusercontent.com/2646053/121236148-a0cc6780-c863-11eb-9275-d0eb0ccb1f5a.mov

**What is the new behavior?**

Line charts show a colored gradient as demonstrated by this [stackblitz](https://stackblitz.com/edit/ngx-charts-line-chart-fix)

https://user-images.githubusercontent.com/2646053/121545929-ef4f4280-c9d8-11eb-86e8-35d182e9dbf7.mov

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Calls update before starting animations to fix gradientId, gradientFill, and gradientStops undefined when data changes.

Fixes #1562
Fixes #1165
Fixes #1158 
Fixes #1062
Fixes #808
Fixes #672

