### PR TITLE
fix: warnings when `npm run build:demo`

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -50,7 +50,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/projects/swimlane/ngx-charts/ng-package.json
+++ b/projects/swimlane/ngx-charts/ng-package.json
@@ -2,7 +2,19 @@
   "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../../dist/swimlane/ngx-charts",
   "lib": {
-    "entryFile": "src/public-api.ts"
+    "entryFile": "src/public-api.ts",
+    "umdModuleIds": {
+      "d3-array": "d3-array",
+      "d3-brush": "d3-brush",
+      "d3-color": "d3-color",
+      "d3-format": "d3-format",
+      "d3-hierarchy": "d3-hierarchy",
+      "d3-interpolate": "d3-interpolate",
+      "d3-scale": "d3-scale",
+      "d3-selection": "d3-selection",
+      "d3-shape": "d3-shape",
+      "d3-time-format": "d3-time-format"
+    }
   },
-  "whitelistedNonPeerDependencies": ["d3"]
+  "allowedNonPeerDependencies": ["d3"]
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)

Currently, there are warnings when building the demo app with `npm run build:demo`.

```bash
> npm run build:demo


> ngx-charts@0.0.0 build:demo /home/runner/work/ngx-charts/ngx-charts
> npm run build:lib:prod && cross-env NODE_ENV=production ng build --configuration production --base-href="/ngx-charts/"


> ngx-charts@0.0.0 build:lib:prod /home/runner/work/ngx-charts/ngx-charts
> ng build @swimlane/ngx-charts --configuration production

Building Angular Package
❗👀 WARNING: Option "whitelistedNonPeerDependencies" is deprecated: Use "allowedNonPeerDependencies" instead.
- Compiling with Angular in legacy View Engine compilation mode.

------------------------------------------------------------------------------
Building entry point '@swimlane/ngx-charts'
------------------------------------------------------------------------------
✔ Compiling with Angular in legacy View Engine compilation mode.
- Bundling to FESM2015
✔ Bundling to FESM2015
- Bundling to UMD
❗👀 WARNING: No name was provided for external module 'd3-selection' in output.globals – guessing 'd3Selection'
❗👀 WARNING: No name was provided for external module 'd3-brush' in output.globals – guessing 'd3Brush'
❗👀 WARNING: No name was provided for external module 'd3-scale' in output.globals – guessing 'd3Scale'
❗👀 WARNING: No name was provided for external module 'd3-shape' in output.globals – guessing 'd3Shape'
❗👀 WARNING: No name was provided for external module 'd3-array' in output.globals – guessing 'd3Array'
❗👀 WARNING: No name was provided for external module 'd3-interpolate' in output.globals – guessing 'd3Interpolate'
❗👀 WARNING: No name was provided for external module 'd3-format' in output.globals – guessing 'd3Format'
❗👀 WARNING: No name was provided for external module 'd3-color' in output.globals – guessing 'd3_color'
❗👀 WARNING: No name was provided for external module 'd3-hierarchy' in output.globals – guessing 'd3Hierarchy'
❗👀 WARNING: No name was provided for external module 'd3-time-format' in output.globals – guessing 'd3TimeFormat'
✔ Bundling to UMD
- Writing package metadata
✔ Writing package metadata
✔ Built @swimlane/ngx-charts

------------------------------------------------------------------------------
Built Angular Package
 - from: /home/runner/work/ngx-charts/ngx-charts/projects/swimlane/ngx-charts
 - to:   /home/runner/work/ngx-charts/ngx-charts/dist/swimlane/ngx-charts
------------------------------------------------------------------------------

Build at: 2021-07-08T20:02:43.508Z - Time: 19548ms

❗👀 Option "extractCss" is deprecated: Deprecated since version 11.0. No longer required to disable CSS extraction for HMR.
- Generating browser application bundles (phase: setup)...

```

**What is the new behavior?**

No warnings when building demo app with `npm run build:demo`.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] No
