### PR TITLE
refactor: remove element-style on heat-map-cell

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.scss
@@ -3,6 +3,7 @@
   overflow: visible;
 
   .circle,
+  .cell,
   .bar,
   .arc {
     cursor: pointer;

--- a/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map-cell.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map-cell.component.ts
@@ -10,10 +10,8 @@ import {
   HostListener
 } from '@angular/core';
 import { select } from 'd3-selection';
-import { Gradient } from '../common/types';
-
+import { Gradient, BarOrientation } from '../common/types';
 import { id } from '../utils/id';
-import { BarOrientation } from '../common/types/bar-orientation.enum';
 
 @Component({
   selector: 'g[ngx-charts-heat-map-cell]',
@@ -33,7 +31,6 @@ import { BarOrientation } from '../common/types/bar-orientation.enum';
         [attr.width]="width"
         [attr.height]="height"
         class="cell"
-        style="cursor: pointer"
         (click)="onClick()"
       />
     </svg:g>

--- a/projects/swimlane/ngx-charts/src/lib/tree-map/tree-map-cell.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/tree-map/tree-map-cell.component.ts
@@ -5,9 +5,8 @@ import { invertColor } from '../utils/color-utils';
 import { trimLabel } from '../common/trim-label.helper';
 import { escapeLabel } from '../common/label.helper';
 import { id } from '../utils/id';
-import { Gradient } from '../common/types';
+import { BarOrientation, Gradient } from '../common/types';
 import { DataItem } from '../models/chart-data.model';
-import { BarOrientation } from '../common/types/bar-orientation.enum';
 
 @Component({
   selector: 'g[ngx-charts-tree-map-cell]',
@@ -27,7 +26,6 @@ import { BarOrientation } from '../common/types/bar-orientation.enum';
         [attr.height]="height"
         [attr.x]="x"
         [attr.y]="y"
-        [style.cursor]="'pointer'"
         class="cell"
         (click)="onClick()"
       />


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)

- `cursor: pointer` style was directly set on the element
- `!important` is needed if one would like to change this style

**What is the new behavior?**

- cursor style is set via css and therefore follows the pattern which is also used for e.g. `.bar`
- this allows to target `.cell` without using `!important`

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No

