### PR TITLE
Fix data type on visibleValue input

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
@@ -107,7 +107,7 @@ export class CircleSeriesComponent implements OnChanges, OnInit {
   @Input() yScale;
   @Input() colors: ColorHelper;
   @Input() scaleType: ScaleType;
-  @Input() visibleValue: boolean;
+  @Input() visibleValue: StringOrNumberOrDate;
   @Input() activeEntries: any[];
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipTemplate: TemplateRef<any>;


### PR DESCRIPTION
Currently, visibleValue is declared as a boolean in this component, but this is not correct at all. visibleValue is a reference to the current x-axis value being displayed, and as such should be of the data type of items that could be on the x-axis, namely String or Number or Date

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When building custom charts using `CircleSeries`, the variable being assigned to `visibleValue` has to be declared as `any` because the component is expecting a `boolean` input, but actually uses it as the value of the x-axis, or `StringOrNumberOrDate`

**What is the new behavior?**
`visibleValue` now accepts the correct datatype `StringOrNumberOrDate`

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No