### PR TITLE
Allow rxjs 7.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ng-in-viewport": "^6.1.5",
     "ngx-moment": "^5.0.0",
     "resize-observer-polyfill": "^1.5.1",
-    "rxjs": "~6.6.0",
+    "rxjs": "~6.6.0 || ~7.4.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
   },


### PR DESCRIPTION
This is the current version for Angular 13, se that's needed for new and upgraded apps.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Angular 13 apps can't use ngx-charts because they use rxjs 7.4 and ngx-charts only accepts rxjs 6.x.

Fixes #1699 

**What is the new behavior?**

Applications that use ngx-charts will work in rxjs 6 and 7.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
