### PR TITLE
#1039 #1446 Handle touch events

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
@@ -7,7 +7,8 @@ import {
   ChangeDetectionStrategy,
   TemplateRef,
   PLATFORM_ID,
-  Inject
+  Inject,
+  HostListener
 } from '@angular/core';
 import { trigger, style, animate, transition } from '@angular/animations';
 import { createMouseEvent } from '../events';
@@ -158,12 +159,24 @@ export class TooltipArea {
     return results;
   }
 
-  mouseMove(event) {
+  @HostListener('touchmove', ['$event'])
+  onTouchMove(event): void {
+    this.mouseMove(event, true);
+  }
+
+  @HostListener('touchend')
+  onTouchEnd(): void {
+    this.hideTooltip();
+  }
+
+  mouseMove(event, isTouchMoveEvent = false) {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
 
-    const xPos = event.pageX - event.target.getBoundingClientRect().left;
+    const pageX = isTouchMoveEvent ? event.targetTouches[0].pageX : event.pageX;
+
+    const xPos = pageX - event.target.getBoundingClientRect().left;
 
     const closestIndex = this.findClosestPointIndex(xPos);
     const closestPoint = this.xSet[closestIndex];

--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
@@ -11,6 +11,8 @@ import {
   ComponentRef
 } from '@angular/core';
 
+import { throttleable } from '../../utils/throttle';
+
 import { PlacementTypes } from './position';
 import { StyleTypes } from './style.type';
 import { ShowTypes } from './show.type';
@@ -76,6 +78,12 @@ export class TooltipDirective implements OnDestroy {
     if (this.listensForFocus) {
       this.hideTooltip(true);
     }
+  }
+
+  @HostListener('window:scroll')
+  @throttleable(100)
+  onWindowScroll(): void {
+    this.hideTooltip(true);
   }
 
   @HostListener('mouseenter')


### PR DESCRIPTION
- Hide tooltip on touch devices when scrolling
- Move over line chart on touch device shows different values

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**Tooltips not hidden when scrolling**
[issue](https://github.com/swimlane/ngx-charts/issues/1039)
On touch device, the tooltip shows on touch, but doesn't disappear when scrolling. Which let it in the middle of the screen.

**(Touch) Move over Line-Charts shows y-Values**
[issue](https://github.com/swimlane/ngx-charts/issues/1446)


**What is the new behavior?**

- The tooltip disappear on scroll.
- We can see the tooltip changing while panning with the finger.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
