### PR TITLE
Adding option to show data point circles (#1742)

### DIFF
--- a/docs/examples/line-area-charts/line-chart.md
+++ b/docs/examples/line-area-charts/line-chart.md
@@ -50,6 +50,7 @@
 | xScaleMax             | any                |               | the maximum value of the x axis \(if the x scale is linear or time\)                                                                                                                                                                       |
 | yScaleMin             | number             |               | the minimum value of the y axis                                                                                                                                                                                                            |
 | yScaleMax             | number             |               | the maximum value of the y axis                                                                                                                                                                                                            |
+| showDataPointCircles  | boolean            | false         | show data point circles                                                                                                                                                                                                                    |
 
 ## Outputs
 

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -137,6 +137,7 @@ import { isPlatformServer } from '@angular/common';
                 [colors]="colors"
                 [data]="series"
                 [scaleType]="scaleType"
+                [showDataPointCircles]="showDataPointCircles"
                 [visibleValue]="hoveredVertical"
                 [activeEntries]="activeEntries"
                 [tooltipDisabled]="tooltipDisabled"
@@ -233,6 +234,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
   @Input() xScaleMax: number;
   @Input() yScaleMin: number;
   @Input() yScaleMax: number;
+  @Input() showDataPointCircles: boolean = false;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -371,6 +371,7 @@
         [rotateXAxisTicks]="rotateXAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
+        [showDataPointCircles]="showDataPointCircles"
         (select)="select($event)"
         (activate)="activate($event)"
         (deactivate)="deactivate($event)"
@@ -1138,6 +1139,12 @@
             <br />
             <input type="checkbox" [(ngModel)]="range" />
             Show min and max values
+          </label>
+
+          <label *ngIf="chart.options.includes('showDataPointCircles')">
+            <br />
+            <input type="checkbox" [(ngModel)]="showDataPointCircles" />
+            Show data point circles
           </label>
         </div>
       </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -181,6 +181,9 @@ export class AppComponent implements OnInit {
   autoScale = true;
   timeline = false;
 
+  // line chart
+  showDataPointCircles: boolean = false;
+
   // margin
   margin: boolean = false;
   marginTop: number = 40;

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -356,7 +356,8 @@ const chartGroups = [
           'trimYAxisTicks',
           'rotateXAxisTicks',
           'maxXAxisTickLength',
-          'maxYAxisTickLength'
+          'maxYAxisTickLength',
+          'showDataPointCircles'
         ],
         defaults: {
           yAxisLabel: 'GDP Per Capita',


### PR DESCRIPTION
recommendation to turn off the animation, because the circles are not animated and therefore they are appearing in the empty plot until the line animation is finished

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The data point circles are only active when the user hovers over the chart. Only the nearest data point has a circle. 
closes #1742

**What is the new behavior?**
The data point circles are always active for all data points in the series.
![image](https://user-images.githubusercontent.com/58370727/157698745-37c4190d-cc63-4d47-baef-1f02afba089c.png)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Recommendation to turn off the animation, because the circles are not animated and therefore they are appearing in the empty plot until the line animation is finished
