### PR TITLE
replace clone-deep import with lodash-es equivalent

### DIFF
--- a/projects/swimlane/ngx-charts/ng-package.json
+++ b/projects/swimlane/ngx-charts/ng-package.json
@@ -4,5 +4,8 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["d3"]
+  "allowedNonPeerDependencies": [
+    "d3",
+    "lodash-es"
+  ]
 }

--- a/projects/swimlane/ngx-charts/package-lock.json
+++ b/projects/swimlane/ngx-charts/package-lock.json
@@ -1,9 +1,37 @@
 {
   "name": "@swimlane/ngx-charts",
-  "version": "16.0.0",
+  "version": "20.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/d3-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
+    },
+    "@types/d3-shape": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "requires": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
+      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "d3-array": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
@@ -122,6 +150,11 @@
         "d3-interpolate": "1 - 2",
         "d3-timer": "1 - 2"
       }
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "tslib": {
       "version": "2.0.3",

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -45,6 +45,7 @@
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
+    "@types/d3-shape": "^2.0.0",
     "d3-array": "^2.9.1",
     "d3-brush": "^2.1.0",
     "d3-color": "^2.0.0",
@@ -56,7 +57,10 @@
     "d3-shape": "^2.0.0",
     "d3-time-format": "^3.0.0",
     "d3-transition": "^2.0.0",
-    "tslib": "^2.0.0",
-    "@types/d3-shape": "^2.0.0"
+    "lodash-es": "^4.17.21",
+    "tslib": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/lodash-es": "^4.17.6"
   }
 }

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -45,7 +45,6 @@
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
-    "@types/d3-shape": "^2.0.0",
     "d3-array": "^2.9.1",
     "d3-brush": "^2.1.0",
     "d3-color": "^2.0.0",
@@ -61,6 +60,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
+    "@types/d3-shape": "^2.0.0",
     "@types/lodash-es": "^4.17.6"
   }
 }

--- a/projects/swimlane/ngx-charts/src/lib/box-chart/box-chart.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/box-chart/box-chart.component.spec.ts
@@ -1,0 +1,54 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { boxData } from '../../../../../../src/app/data';
+import { BoxChartModule } from './box-chart.module';
+
+@Component({
+  selector: 'test-component',
+  template: ''
+})
+class TestComponent {
+  data: any = boxData;
+  colorScheme = {
+    domain: ['#5AA454', '#A10A28', '#C7B42C', '#AAAAAA']
+  };
+}
+
+describe('<ngx-charts-box-chart>', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NoopAnimationsModule, BoxChartModule],
+      providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+    });
+  });
+
+  describe('basic setup', () => {
+    beforeEach(() => {
+      TestBed.overrideComponent(TestComponent, {
+        set: {
+          template: `
+               <ngx-charts-box-chart
+                [animations]="true"
+                [view]="[400,800]"
+                [scheme]="colorScheme"
+                [results]="data">
+              </ngx-charts-box-chart>`
+        }
+      });
+    });
+
+    it('should set the svg width and height', () => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const svg = fixture.debugElement.nativeElement.querySelector('svg');
+
+      expect(svg.getAttribute('width')).toBe('400');
+      expect(svg.getAttribute('height')).toBe('800');
+    });
+  });
+});

--- a/projects/swimlane/ngx-charts/src/lib/box-chart/box.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/box-chart/box.component.ts
@@ -14,8 +14,7 @@ import { select, BaseType } from 'd3-selection';
 import { interpolate } from 'd3-interpolate';
 import { easeSinInOut } from 'd3-ease';
 
-import cloneDeep from 'clone-deep';
-
+import { cloneDeep } from 'lodash-es';
 import { roundedRect } from '../common/shape.helper';
 import { id } from '../utils/id';
 import { IBoxModel } from '../models/chart-data.model';
@@ -281,8 +280,13 @@ export class BoxComponent implements OnChanges {
 
     const lineCoordinates: LineCoordinates = cloneDeep(this.lineCoordinates);
 
-    lineCoordinates[1].v1.y = lineCoordinates[1].v2.y = lineCoordinates[3].v1.y = lineCoordinates[3].v2.y = lineCoordinates[0].v1.y = lineCoordinates[0].v2.y =
-      lineCoordinates[2].v1.y;
+    lineCoordinates[1].v1.y =
+      lineCoordinates[1].v2.y =
+      lineCoordinates[3].v1.y =
+      lineCoordinates[3].v2.y =
+      lineCoordinates[0].v1.y =
+      lineCoordinates[0].v2.y =
+        lineCoordinates[2].v1.y;
 
     return lineCoordinates;
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, the box chart imports clone-deep, which is a CommonJS dependency. This causes the Angular CLI to throw a warning regarding potential optimization bailouts.
Please see the issue below:
https://github.com/swimlane/ngx-charts/issues/1688


**What is the new behavior?**
Adding lodash-es as a dependency and using the cloneDeep function instead. This version is tree-shakeable and in a ES6 format.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
