### PR TITLE
Remove clone-deep dependency

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/box-chart/box.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/box-chart/box.component.ts
@@ -14,16 +14,47 @@ import { select, BaseType } from 'd3-selection';
 import { interpolate } from 'd3-interpolate';
 import { easeSinInOut } from 'd3-ease';
 
-import cloneDeep from 'clone-deep';
-
 import { roundedRect } from '../common/shape.helper';
 import { id } from '../utils/id';
 import { IBoxModel } from '../models/chart-data.model';
-import { IVector2D } from '../models/coordinates.model';
+import { IVector2D, IPoint } from '../models/coordinates.model';
 import { BarOrientation } from '../common/types/bar-orientation.enum';
 import { Gradient } from '../common/types/gradient.interface';
 
 type LineCoordinates = [IVector2D, IVector2D, IVector2D, IVector2D];
+
+export function clonePoint(original: IPoint): IPoint {
+  if (!original) {
+    return original;
+  }
+  return {
+    x: original.x,
+    y: original.y
+  };
+}
+
+export function cloneVector2d(original: IVector2D): IVector2D {
+  if (!original) {
+    return original;
+  }
+  return {
+      v1: clonePoint(original.v1),
+      v2: clonePoint(original.v2)
+  };
+}
+
+export function cloneLineCoordinates(original: LineCoordinates): LineCoordinates {
+  if (!original) {
+    return original;
+  }
+  return [
+    cloneVector2d(original[0]),
+    cloneVector2d(original[1]),
+    cloneVector2d(original[2]),
+    cloneVector2d(original[3])
+  ]
+}
+
 
 @Component({
   selector: 'g[ngx-charts-box]',
@@ -279,7 +310,7 @@ export class BoxComponent implements OnChanges {
       return [...this.lineCoordinates];
     }
 
-    const lineCoordinates: LineCoordinates = cloneDeep(this.lineCoordinates);
+    const lineCoordinates: LineCoordinates = cloneLineCoordinates(this.lineCoordinates);
 
     lineCoordinates[1].v1.y = lineCoordinates[1].v2.y = lineCoordinates[3].v1.y = lineCoordinates[3].v2.y = lineCoordinates[0].v1.y = lineCoordinates[0].v2.y =
       lineCoordinates[2].v1.y;


### PR DESCRIPTION
Removing the clone-deep dependency is possible by writing a custom clone function for Line Coordinates. 

This closes #1762

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, a dependency on 4 year old `clone-deep` causes an optimization bailout warning, and an error in Angular 14 compilation.

**What is the new behavior?**

Removing a function call which was only used once, and replacing it with a monomorphic function, improves the performance and removes this breaking error.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
