### PR TITLE
change ios timeout

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
@@ -112,7 +112,7 @@ export class TooltipDirective implements OnDestroy {
 
     const time = immediate
       ? 0
-      : this.tooltipShowTimeout + (navigator.userAgent.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/) ? 300 : 0);
+      : this.tooltipShowTimeout + (navigator.userAgent.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/) ? 400 : 0);
 
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {


### PR DESCRIPTION
Modify timeout time from 300 to 400 on iOS

fixes [#1228](https://github.com/swimlane/ngx-charts/issues/1228)

**What kind of change does this PR introduce?** (check one with "x")
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Tooltips don't display in various chart types on iOS devices (e.g, bar chart)

**What is the new behavior?**

Tooltips do display on iOS devices

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
