### PR TITLE
ngx-charts-gauge, numbers < 10 It will display properly when you do not give the units attribute.

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
@@ -285,8 +285,8 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
     }
     const { width } = this.textEl.nativeElement.getBoundingClientRect();
     const oldScale = this.resizeScale;
-
-    if (width === 0 || this.units == "") {
+    console.log(1)
+    if (width === 0 || this.units == "" || this.units == undefined) {
       this.resizeScale = 1;
     } else {
       const availableSpace = this.textRadius;

--- a/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/gauge.component.ts
@@ -286,7 +286,7 @@ export class GaugeComponent extends BaseChartComponent implements AfterViewInit 
     const { width } = this.textEl.nativeElement.getBoundingClientRect();
     const oldScale = this.resizeScale;
 
-    if (width === 0) {
+    if (width === 0 || this.units == "") {
       this.resizeScale = 1;
     } else {
       const availableSpace = this.textRadius;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When someone Missing units attribute, like this in example it will show wrong scaling of text mentioned in screenshot.
<ngx-charts-gauge [view]="view" [results]="single" [legend]="legend" (select)="onSelect($event)"
  (activate)="onActivate($event)" (deactivate)="onDeactivate($event)">
</ngx-charts-gauge>
![overflow](https://user-images.githubusercontent.com/49456702/194149729-86944369-9700-4168-82a4-c3934ec6fef1.png)
https://github.com/swimlane/ngx-charts/issues/1790


**What is the new behavior?**
Now, When you are not giving units attribute, it will work fine completly not overflow happens.
![issueSolved](https://user-images.githubusercontent.com/49456702/194149858-2afb632b-53cf-4d1a-a121-0737125302ff.png)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
No breaking changes

**Other information**:
