### PR TITLE
Adjustable angle of the pie chart series to show the label

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-chart.component.ts
@@ -9,6 +9,7 @@ import {
   TemplateRef
 } from '@angular/core';
 import { calculateViewDimensions } from '../common/view-dimensions.helper';
+import { degreesToRadians } from '../utils/convert-angle';
 import { ColorHelper } from '../common/color.helper';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { DataItem } from '../models/chart-data.model';
@@ -47,6 +48,7 @@ import { ScaleType } from '../common/types/scale-type.enum';
           [tooltipDisabled]="tooltipDisabled"
           [tooltipTemplate]="tooltipTemplate"
           [tooltipText]="tooltipText"
+          [minRadiansToShowLabel]="getMinRadiansToShowLabel()"
           (dblclick)="dblclick.emit($event)"
           (select)="onClick($event)"
           (activate)="onActivate($event)"
@@ -73,6 +75,7 @@ export class PieChartComponent extends BaseChartComponent {
   @Input() labelFormatting: any;
   @Input() trimLabels: boolean = true;
   @Input() maxLabelLength: number = 10;
+  @Input() minDegreesToShowLabel: number = 6
   @Input() tooltipText: any;
   @Output() dblclick = new EventEmitter();
   // optional margins
@@ -140,6 +143,10 @@ export class PieChartComponent extends BaseChartComponent {
 
   getDomain(): string[] {
     return this.results.map(d => d.label);
+  }
+
+  getMinRadiansToShowLabel(): number {
+    return degreesToRadians(this.minDegreesToShowLabel);
   }
 
   onClick(data: DataItem | string): void {

--- a/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/pie-chart/pie-series.component.ts
@@ -84,6 +84,7 @@ export class PieSeriesComponent implements OnChanges {
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipTemplate: TemplateRef<any>;
   @Input() animations: boolean = true;
+  @Input() minRadiansToShowLabel: number = Math.PI / 30;
 
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -164,7 +165,8 @@ export class PieSeriesComponent implements OnChanges {
   }
 
   labelVisible(myArc): boolean {
-    return this.showLabels && myArc.endAngle - myArc.startAngle > Math.PI / 30;
+    const angle =  myArc.endAngle - myArc.startAngle;
+    return this.showLabels && angle >= this.minRadiansToShowLabel && angle > 0;
   }
 
   getTooltipTitle(a) {

--- a/projects/swimlane/ngx-charts/src/lib/utils/convert-angle.ts
+++ b/projects/swimlane/ngx-charts/src/lib/utils/convert-angle.ts
@@ -1,0 +1,3 @@
+export function degreesToRadians(degrees: number) {
+    return degrees * Math.PI / 180;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -301,6 +301,7 @@
         [gradient]="gradient"
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
+        [minDegreesToShowLabel]="minDegreesToShowLabel"
         (dblclick)="dblclick($event)"
         (select)="select($event)"
         (activate)="activate($event)"
@@ -1389,6 +1390,10 @@
             Explode Slices
           </label>
           <br />
+        </div>
+        <div *ngIf="chart.options.includes('minDegreesToShowLabel') && !doughnut">
+          <label>Min series angle to show the label (°):</label><br />
+          <input type="number" [(ngModel)]="minDegreesToShowLabel" min="0" max="360" />
         </div>
         <div *ngIf="chart.options.includes('autoScale')">
           <label>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -176,6 +176,7 @@ export class AppComponent implements OnInit {
   explodeSlices = false;
   doughnut = false;
   arcWidth = 0.25;
+  minDegreesToShowLabel = 6;
 
   // line, area
   autoScale = true;

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -300,7 +300,8 @@ const chartGroups = [
           'arcWidth',
           'explodeSlices',
           'showLabels',
-          'tooltipDisabled'
+          'tooltipDisabled',
+          'minDegreesToShowLabel'
         ]
       },
       {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-charts/issues/1825
Currently labels in pie-chart are shown only if series angle is grater than Math.PI / 30.

**What is the new behavior?**
A new parameter named `minDegreesToShowLabel` has been added. Now the user can set which labels will be visible by specifying the minimum value of the series angle.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Only pie-chart was affected.

**Other information**:
Closes #1825 
