### PR TITLE
Fix legends truncated on Safari

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -76,7 +76,7 @@
     vertical-align: top;
     line-height: 15px;
     font-size: 12px;
-    width: calc(100% - 20px);
+    width: calc(100% - 10px);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Safari renders an ellipsis even though there is enough space, #1537


**What is the new behavior?**
Ellipsis is no longer rendered because the span is wide enough


**Does this PR introduce a breaking change?** (check one with "x")
- [] ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
This might break #487, but I tested his use case on the website and it seems 10px suffice to show the ellipsis:
![Screenshot 2023-01-24 at 18 18 28](https://user-images.githubusercontent.com/36509607/214364018-2d230f25-82ef-4476-9715-1b83e8808126.jpg)

**Other information**:
