### PR TITLE
add providedIn: 'root'

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/injection.service.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/injection.service.ts
@@ -21,7 +21,9 @@ function isViewContainerRef(x: any): x is ViewContainerRef {
  *
  * @export
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class InjectionService {
   static globalRootViewContainer: ViewContainerRef = null;
 

--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.service.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { InjectionService } from './injection.service';
 import { TooltipContentComponent } from './tooltip.component';
 import { InjectionRegisteryService } from './injection-registery.service';
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class TooltipService extends InjectionRegisteryService<TooltipContentComponent> {
   type: any = TooltipContentComponent;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-charts/issues/1733
Right now we cannot lazy load ngx-chart module as it will throw an error about null Injection.


**What is the new behavior?**
ngx-chart will now be able to lazy load.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
