### PR TITLE
Fix: use width instead of height to compute spacing of vertical bar groups

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-2d.component.ts
@@ -265,7 +265,7 @@ export class BarVertical2DComponent extends BaseChartComponent {
   }
 
   getGroupScale(): any {
-    const spacing = this.groupDomain.length / (this.dims.height / this.groupPadding + 1);
+    const spacing = this.groupDomain.length / (this.dims.width / this.groupPadding + 1);
 
     return scaleBand()
       .rangeRound([0, this.dims.width])


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Incorrect computation of the spacing between vertical bar groups causes the bars to become very thin in some cases.
Example: https://stackblitz.com/edit/angular-simple-ngx-charts-zqwhqv?file=src%2Fapp%2Fapp.component.html
It should use the width of the component to determine the horizontal spacing.

**What is the new behavior?**
Bars have the correct width and group padding.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
