### PR TITLE
feature: make axis limits for line charts explicitly nullable

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -231,10 +231,10 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
   @Input() showRefLines: boolean = false;
   @Input() referenceLines: any;
   @Input() showRefLabels: boolean = true;
-  @Input() xScaleMin: number;
-  @Input() xScaleMax: number;
-  @Input() yScaleMin: number;
-  @Input() yScaleMax: number;
+  @Input() xScaleMin: number | null;
+  @Input() xScaleMax: number | null;
+  @Input() yScaleMin: number | null;
+  @Input() yScaleMax: number | null;
   @Input() wrapTicks = false;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
make axis limits for line charts explicitly nullable, so thy work correctly with strictly typed applications

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When developing an application with strict null typings, axis limits can not be set to null, so they are determined automatically.

**What is the new behavior?**

Typing is explicitly nullable, so the API reflects that these values are optional (as the implementation already handles it).

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
