### PR TITLE
feat: The legend displays black in light mode

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -1,3 +1,13 @@
+.light .chart-legend {
+  .legend-label {
+    color: #000;
+
+    .active .legend-label-text {
+      color: #afb7c8;
+    }
+  }
+}
+
 .chart-legend {
   display: inline-block;
   padding: 0;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Under the Light theme, the color of the legend text is inconsistent with the color of the coordinate axis text, and because of the white background, the legend text is not easy to see clearly


**What is the new behavior?**
Change the legend text color to black in the Light theme


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
