### PR TITLE
New 2d bubble chart

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart-2d.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart-2d.component.ts
@@ -1,0 +1,446 @@
+import {
+    Component,
+    Input,
+    Output,
+    EventEmitter,
+    HostListener,
+    ViewEncapsulation,
+    ChangeDetectionStrategy,
+    ContentChild,
+    TemplateRef
+  } from '@angular/core';
+  import { trigger, style, animate, transition } from '@angular/animations';
+  import { scaleLinear } from 'd3-scale';
+
+  import { BaseChartComponent } from '../common/base-chart.component';
+  import { calculateViewDimensions } from '../common/view-dimensions.helper';
+  import { ColorHelper } from '../common/color.helper';
+  import { getScaleType } from '../common/domain.helper';
+  import { getDomain, getScale } from './bubble-chart.utils';
+  import { id } from '../utils/id';
+  import { BubbleChartSeries } from '../models/chart-data.model';
+  import { LegendOptions, LegendPosition } from '../common/types/legend.model';
+  import { ScaleType } from '../common/types/scale-type.enum';
+  import { ViewDimensions } from '../common/types/view-dimension.interface';
+  import { isPlatformServer } from '@angular/common';
+
+  @Component({
+    selector: 'ngx-charts-bubble-chart-2d',
+    template: `
+      <ngx-charts-chart
+        [view]="[width, height]"
+        [showLegend]="legend"
+        [activeEntries]="activeEntries"
+        [legendOptions]="legendOptions"
+        [animations]="animations"
+        (legendLabelClick)="onClick($event)"
+        (legendLabelActivate)="onActivate($event)"
+        (legendLabelDeactivate)="onDeactivate($event)"
+      >
+        <svg:defs>
+          <svg:clipPath [attr.id]="clipPathId">
+            <svg:rect
+              [attr.width]="dims.width + 10"
+              [attr.height]="dims.height + 10"
+              [attr.transform]="'translate(-5, -5)'"
+            />
+          </svg:clipPath>
+        </svg:defs>
+        <svg:g [attr.transform]="transform" class="bubble-chart chart">
+          <svg:g
+            ngx-charts-x-axis
+            *ngIf="xAxis"
+            [showGridLines]="showGridLines"
+            [dims]="dims"
+            [xScale]="xScale"
+            [showLabel]="showXAxisLabel"
+            [labelText]="xAxisLabel"
+            [trimTicks]="trimXAxisTicks"
+            [rotateTicks]="rotateXAxisTicks"
+            [maxTickLength]="maxXAxisTickLength"
+            [tickFormatting]="xAxisTickFormatting"
+            [ticks]="xAxisTicks"
+            [wrapTicks]="wrapTicks"
+            (dimensionsChanged)="updateXAxisHeight($event)"
+          />
+          <svg:g
+            ngx-charts-y-axis
+            *ngIf="yAxis"
+            [showGridLines]="showGridLines"
+            [yScale]="yScale"
+            [dims]="dims"
+            [showLabel]="showYAxisLabel"
+            [labelText]="yAxisLabel"
+            [trimTicks]="trimYAxisTicks"
+            [maxTickLength]="maxYAxisTickLength"
+            [tickFormatting]="yAxisTickFormatting"
+            [ticks]="yAxisTicks"
+            [wrapTicks]="wrapTicks"
+            (dimensionsChanged)="updateYAxisWidth($event)"
+          />
+          <svg:rect
+            class="bubble-chart-area"
+            x="0"
+            y="0"
+            [attr.width]="dims.width"
+            [attr.height]="dims.height"
+            style="fill: rgb(255, 0, 0); opacity: 0; cursor: 'auto';"
+            (mouseenter)="deactivateAll()"
+          />
+          <svg:g *ngIf="!isSSR" [attr.clip-path]="clipPath">
+            <svg:g *ngFor="let series of data; trackBy: trackBy" [@animationState]="'active'">
+              <svg:g
+                ngx-charts-bubble-series
+                [xScale]="xScale"
+                [yScale]="yScale"
+                [rScale]="rScale"
+                [xScaleType]="xScaleType"
+                [yScaleType]="yScaleType"
+                [xAxisLabel]="xAxisLabel"
+                [yAxisLabel]="yAxisLabel"
+                [colors]="colors"
+                [data]="series"
+                [activeEntries]="activeEntries"
+                [tooltipDisabled]="tooltipDisabled"
+                [tooltipTemplate]="tooltipTemplate"
+                (select)="onClick($event, series)"
+                (activate)="onActivate($event)"
+                (deactivate)="onDeactivate($event)"
+              />
+            </svg:g>
+          </svg:g>
+          <svg:g *ngIf="isSSR" [attr.clip-path]="clipPath">
+            <svg:g *ngFor="let series of data; trackBy: trackBy">
+              <svg:g
+                ngx-charts-bubble-series
+                [xScale]="xScale"
+                [yScale]="yScale"
+                [rScale]="rScale"
+                [xScaleType]="xScaleType"
+                [yScaleType]="yScaleType"
+                [xAxisLabel]="xAxisLabel"
+                [yAxisLabel]="yAxisLabel"
+                [colors]="colors"
+                [data]="series"
+                [activeEntries]="activeEntries"
+                [tooltipDisabled]="tooltipDisabled"
+                [tooltipTemplate]="tooltipTemplate"
+                (select)="onClick($event, series)"
+                (activate)="onActivate($event)"
+                (deactivate)="onDeactivate($event)"
+              />
+            </svg:g>
+          </svg:g>
+        </svg:g>
+      </ngx-charts-chart>
+    `,
+    styleUrls: ['../common/base-chart.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
+    animations: [
+      trigger('animationState', [
+        transition(':leave', [
+          style({
+            opacity: 1
+          }),
+          animate(
+            500,
+            style({
+              opacity: 0
+            })
+          )
+        ])
+      ])
+    ]
+  })
+  export class BubbleChart2DComponent extends BaseChartComponent {
+    @Input() showGridLines: boolean = true;
+    @Input() legend = false;
+    @Input() legendTitle: string = 'Legend';
+    @Input() legendPosition: LegendPosition = LegendPosition.Right;
+    @Input() xAxis: boolean = true;
+    @Input() yAxis: boolean = true;
+    @Input() showXAxisLabel: boolean;
+    @Input() showYAxisLabel: boolean;
+    @Input() xAxisLabel: string;
+    @Input() yAxisLabel: string;
+    @Input() trimXAxisTicks: boolean = true;
+    @Input() trimYAxisTicks: boolean = true;
+    @Input() rotateXAxisTicks: boolean = true;
+    @Input() maxXAxisTickLength: number = 16;
+    @Input() maxYAxisTickLength: number = 16;
+    @Input() xAxisTickFormatting: any;
+    @Input() yAxisTickFormatting: any;
+    @Input() xAxisTicks: any[];
+    @Input() yAxisTicks: any[];
+    @Input() roundDomains: boolean = false;
+    @Input() maxRadius: number = 10;
+    @Input() minRadius: number = 3;
+    @Input() autoScale: boolean;
+    @Input() schemeType: ScaleType = ScaleType.Ordinal;
+    @Input() tooltipDisabled: boolean = false;
+    @Input() xScaleMin: number;
+    @Input() xScaleMax: number;
+    @Input() yScaleMin: number;
+    @Input() yScaleMax: number;
+    @Input() wrapTicks = false;
+
+    @Output() activate: EventEmitter<any> = new EventEmitter();
+    @Output() deactivate: EventEmitter<any> = new EventEmitter();
+
+    @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+
+    dims: ViewDimensions;
+    colors: ColorHelper;
+    scaleType: ScaleType = ScaleType.Linear;
+    margin: number[] = [10, 20, 10, 20];
+    bubblePadding: number[] = [0, 0, 0, 0];
+    data: BubbleChartSeries[];
+
+    legendOptions: LegendOptions;
+    transform: string;
+
+    clipPath: string;
+    clipPathId: string;
+
+    seriesDomain: number[];
+    xDomain: number[];
+    yDomain: string[];
+    rDomain: number[];
+
+    xScaleType: ScaleType;
+    yScaleType: ScaleType;
+
+    yScale: any;
+    xScale: any;
+    rScale: any;
+
+    xAxisHeight: number = 0;
+    yAxisWidth: number = 0;
+
+    activeEntries: any[] = [];
+
+    isSSR = false;
+
+    ngOnInit() {
+      if (isPlatformServer(this.platformId)) {
+        this.isSSR = true;
+      }
+    }
+
+    update(): void {
+      super.update();
+
+      this.dims = calculateViewDimensions({
+        width: this.width,
+        height: this.height,
+        margins: this.margin,
+        showXAxis: this.xAxis,
+        showYAxis: this.yAxis,
+        xAxisHeight: this.xAxisHeight,
+        yAxisWidth: this.yAxisWidth,
+        showXLabel: this.showXAxisLabel,
+        showYLabel: this.showYAxisLabel,
+        showLegend: this.legend,
+        legendType: this.schemeType,
+        legendPosition: this.legendPosition
+      });
+
+      this.seriesDomain = this.results.map(d => d.name);
+      this.rDomain = this.getRDomain();
+      this.xDomain = this.getXDomain();
+      this.yDomain = this.getYDomain();
+
+      this.transform = `translate(${this.dims.xOffset},${this.margin[0]})`;
+
+      const colorDomain = this.schemeType === ScaleType.Ordinal ? this.seriesDomain : this.rDomain;
+      this.colors = new ColorHelper(this.scheme, this.schemeType, colorDomain, this.customColors);
+
+      this.data = this.results;
+
+      this.minRadius = Math.max(this.minRadius, 1);
+      this.maxRadius = Math.max(this.maxRadius, 1);
+
+      this.rScale = this.getRScale(this.rDomain, [this.minRadius, this.maxRadius]);
+
+      this.bubblePadding = [0, 0, 0, 0];
+      this.setScales();
+
+      this.bubblePadding = this.getBubblePadding();
+      this.setScales();
+
+      this.legendOptions = this.getLegendOptions();
+
+      this.clipPathId = 'clip' + id().toString();
+      this.clipPath = `url(#${this.clipPathId})`;
+    }
+
+    @HostListener('mouseleave')
+    hideCircles(): void {
+      this.deactivateAll();
+    }
+
+    onClick(data, series?): void {
+      if (series) {
+        data.series = series.name;
+      }
+
+      this.select.emit(data);
+    }
+
+    getBubblePadding(): number[] {
+      let yMin = 0;
+      let xMin = 0;
+      let yMax = this.dims.height;
+      let xMax = this.dims.width;
+
+      for (const s of this.data) {
+        for (const d of s.series) {
+          const r = this.rScale(d.r);
+          const cx = this.xScaleType === ScaleType.Linear ? this.xScale(Number(d.x)) : this.xScale(d.x);
+          const cy = this.yScale(s.name);
+          xMin = Math.max(r - cx, xMin);
+          yMin = Math.max(r - cy, yMin);
+          yMax = Math.max(cy + r, yMax);
+          xMax = Math.max(cx + r, xMax);
+        }
+      }
+
+      xMax = Math.max(xMax - this.dims.width, 0);
+      yMax = Math.max(yMax - this.dims.height, 0);
+
+      return [yMin, xMax, yMax, xMin];
+    }
+
+    setScales() {
+      let width = this.dims.width;
+      if (this.xScaleMin === undefined && this.xScaleMax === undefined) {
+        width = width - this.bubblePadding[1];
+      }
+      let height = this.dims.height;
+      if (this.yScaleMin === undefined && this.yScaleMax === undefined) {
+        height = height - this.bubblePadding[2];
+      }
+      this.xScale = this.getXScale(this.xDomain, width);
+      this.yScale = this.getYScale(this.yDomain, height);
+    }
+
+    getYScale(domain, height: number): any {
+      return getScale(domain, [height, this.bubblePadding[0]], this.yScaleType, this.roundDomains);
+    }
+
+    getXScale(domain, width: number): any {
+      return getScale(domain, [this.bubblePadding[3], width], this.xScaleType, this.roundDomains);
+    }
+
+    getRScale(domain, range): any {
+      const scale = scaleLinear().range(range).domain(domain);
+
+      return this.roundDomains ? scale.nice() : scale;
+    }
+
+    getLegendOptions(): LegendOptions {
+      const opts = {
+        scaleType: this.schemeType as any,
+        colors: undefined,
+        domain: [],
+        position: this.legendPosition,
+        title: undefined
+      };
+
+      if (opts.scaleType === ScaleType.Ordinal) {
+        opts.domain = this.seriesDomain;
+        opts.colors = this.colors;
+        opts.title = this.legendTitle;
+      } else {
+        opts.domain = this.rDomain;
+        opts.colors = this.colors.scale;
+      }
+
+      return opts;
+    }
+
+    getXDomain(): number[] {
+      const values = [];
+
+      for (const results of this.results) {
+        for (const d of results.series) {
+          if (!values.includes(d.x)) {
+            values.push(d.x);
+          }
+        }
+      }
+
+      this.xScaleType = getScaleType(values);
+      return getDomain(values, this.xScaleType, this.autoScale, this.xScaleMin, this.xScaleMax);
+    }
+
+    getYDomain(): string[] {
+      const values = [];
+      for (const results of this.results) {
+        values.push(results.name);
+      }
+      this.yScaleType = getScaleType(values);
+      return this.results.map(d => d.name);
+    }
+
+    getRDomain(): [number, number] {
+      let min = Infinity;
+      let max = -Infinity;
+
+      for (const results of this.results) {
+        for (const d of results.series) {
+          const value = Number(d.r) || 1;
+          min = Math.min(min, value);
+          max = Math.max(max, value);
+        }
+      }
+
+      return [min, max];
+    }
+
+    updateYAxisWidth({ width }: { width: number }): void {
+      this.yAxisWidth = width;
+      this.update();
+    }
+
+    updateXAxisHeight({ height }: { height: number }): void {
+      this.xAxisHeight = height;
+      this.update();
+    }
+
+    onActivate(item): void {
+      const idx = this.activeEntries.findIndex(d => {
+        return d.name === item.name;
+      });
+      if (idx > -1) {
+        return;
+      }
+
+      this.activeEntries = [item, ...this.activeEntries];
+      this.activate.emit({ value: item, entries: this.activeEntries });
+    }
+
+    onDeactivate(item): void {
+      const idx = this.activeEntries.findIndex(d => {
+        return d.name === item.name;
+      });
+
+      this.activeEntries.splice(idx, 1);
+      this.activeEntries = [...this.activeEntries];
+
+      this.deactivate.emit({ value: item, entries: this.activeEntries });
+    }
+
+    deactivateAll(): void {
+      this.activeEntries = [...this.activeEntries];
+      for (const entry of this.activeEntries) {
+        this.deactivate.emit({ value: entry, entries: [] });
+      }
+      this.activeEntries = [];
+    }
+
+    trackBy(index: number, item): string {
+      return `${item.name}`;
+    }
+  }

--- a/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.module.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-chart.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { ChartCommonModule } from '../common/chart-common.module';
 import { BubbleChartComponent } from './bubble-chart.component';
 import { BubbleSeriesComponent } from './bubble-series.component';
+import { BubbleChart2DComponent } from './bubble-chart-2d.component';
 
 @NgModule({
   imports: [ChartCommonModule],
-  declarations: [BubbleChartComponent, BubbleSeriesComponent],
-  exports: [BubbleChartComponent, BubbleSeriesComponent]
+  declarations: [BubbleChartComponent, BubbleSeriesComponent, BubbleChart2DComponent],
+  exports: [BubbleChartComponent, BubbleSeriesComponent, BubbleChart2DComponent]
 })
 export class BubbleChartModule {}

--- a/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bubble-chart/bubble-series.component.ts
@@ -181,6 +181,49 @@ export class BubbleSeriesComponent implements OnChanges, OnInit {
             isActive,
             transform: `translate(${cx},${cy})`
           };
+        } else {
+          const y = this.data.name;
+          const x = d.x;
+          const r = d.r;
+
+          const radius = this.rScale(r || 1);
+          const tooltipLabel = formatLabel(this.data.name);
+
+          const cx = this.xScaleType === ScaleType.Linear ? this.xScale(Number(x)) : this.xScale(x);
+          const cy = this.yScaleType === ScaleType.Linear ? this.yScale(Number(y)) : this.yScale(y);
+
+          const color =
+            this.colors.scaleType === ScaleType.Linear ? this.colors.getColor(r) : this.colors.getColor(seriesName);
+
+          const isActive = !this.activeEntries.length ? true : this.isActive({ name: seriesName });
+          const opacity = isActive ? 1 : 0.3;
+
+          const data = Object.assign({}, d, {
+            series: seriesName,
+            name: this.data.name,
+            value: this.data.name,
+            x: d.x,
+            radius: d.r
+          });
+
+          return {
+            data,
+            x,
+            y,
+            r,
+            classNames: [`circle-data-${i}`],
+            value: y,
+            label: x,
+            cx,
+            cy,
+            radius,
+            tooltipLabel,
+            color,
+            opacity,
+            seriesName,
+            isActive,
+            transform: `translate(${cx},${cy})`
+          };
         }
       })
       .filter(circle => circle !== undefined);
@@ -198,7 +241,9 @@ export class BubbleSeriesComponent implements OnChanges, OnInit {
     const y = formatLabel(circle.y);
     const name =
       hasSeriesName && hasTooltipLabel
-        ? `${circle.seriesName} • ${circle.tooltipLabel}`
+        ? circle.seriesName === circle.tooltipLabel
+          ? circle.seriesName
+          : `${circle.seriesName} • ${circle.tooltipLabel}`
         : circle.seriesName + circle.tooltipLabel;
     const tooltipTitle =
       hasSeriesName || hasTooltipLabel ? `<span class="tooltip-label">${escapeLabel(name)}</span>` : '';

--- a/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
+++ b/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
@@ -61,6 +61,19 @@ export interface BubbleChartSeries {
 
 export interface BubbleChartMultiSeries extends Array<BubbleChartSeries> {}
 
+export interface BubbleChart2DDataItem {
+  x: StringOrNumberOrDate;
+  r: number;
+  extra?: any;
+}
+
+export interface BubbleChart2DSeries {
+  name: StringOrNumberOrDate;
+  series: BubbleChart2DDataItem[];
+}
+
+export interface BubbleChart2DMultiSeries extends Array<BubbleChart2DSeries> {}
+
 export interface TreeMapDataItem {
   name: StringOrNumberOrDate;
   size?: number;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -990,7 +990,7 @@
         class="chart-container"
         [scheme]="colorScheme"
         [schemeType]="schemeType"
-        [results]="single"
+        [results]="multi"
         [animations]="animations"
         [legend]="showLegend"
         [legendTitle]="legendTitle"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -946,13 +946,51 @@
         >
         </ngx-charts-bubble-chart-interactive>
       </div>
+      <ngx-charts-bubble-chart-2d
+      *ngIf="chartType === 'bubble-chart-2d'"
+      [view]="view"
+      class="chart-container"
+      [results]="bubble2d"
+      [animations]="animations"
+      [showGridLines]="showGridLines"
+      [legend]="showLegend"
+      [legendTitle]="legendTitle"
+      [legendPosition]="legendPosition"
+      [xAxis]="showXAxis"
+      [yAxis]="showYAxis"
+      [showXAxisLabel]="showXAxisLabel"
+      [showYAxisLabel]="showYAxisLabel"
+      [xAxisLabel]="xAxisLabel"
+      [yAxisLabel]="yAxisLabel"
+      [autoScale]="autoScale"
+      [xScaleMin]="xScaleMin"
+      [xScaleMax]="xScaleMax"
+      [yScaleMin]="yScaleMin"
+      [yScaleMax]="yScaleMax"
+      [scheme]="colorScheme"
+      [schemeType]="schemeType"
+      [roundDomains]="roundDomains"
+      [tooltipDisabled]="tooltipDisabled"
+      [minRadius]="minRadius"
+      [maxRadius]="maxRadius"
+      [trimXAxisTicks]="trimXAxisTicks"
+      [trimYAxisTicks]="trimYAxisTicks"
+      [rotateXAxisTicks]="rotateXAxisTicks"
+      [maxXAxisTickLength]="maxXAxisTickLength"
+      [maxYAxisTickLength]="maxYAxisTickLength"
+      [wrapTicks]="wrapTicks"
+      (activate)="activate($event)"
+      (deactivate)="deactivate($event)"
+      (select)="select($event)"
+    >
+    </ngx-charts-bubble-chart-2d>
       <ngx-charts-line-chart
         *ngIf="chartType === 'line-reference-lines'"
         [view]="view"
         class="chart-container"
         [scheme]="colorScheme"
         [schemeType]="schemeType"
-        [results]="multi"
+        [results]="single"
         [animations]="animations"
         [legend]="showLegend"
         [legendTitle]="legendTitle"
@@ -1156,6 +1194,7 @@
         <pre *ngIf="chart.inputFormat === 'boxMultiSeries'">{{ boxData | json }}</pre>
         <pre *ngIf="chart.inputFormat === 'bubble'">{{ bubble | json }}</pre>
         <pre *ngIf="chart.inputFormat === 'bubbleInteractive'">{{ bubbleDemoTempData | json }}</pre>
+        <pre *ngIf="chart.inputFormat === 'bubble2d'">{{ bubble2d | json }}</pre>
         <pre *ngIf="chart.inputFormat === 'comboChart'">{{ barChart | json }}</pre>
         <pre *ngIf="chart.inputFormat === 'comboChart'">{{ lineChartSeries | json }}</pre>
         <pre *ngIf="chart.inputFormat === 'timelineFilter'">{{ timelineFilterBarData | json }}</pre>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import {
   multi,
   boxData,
   bubble,
+  bubble2d,
   sankeyData,
   generateData,
   generateGraph,
@@ -73,6 +74,7 @@ export class AppComponent implements OnInit {
   timelineFilterBarData: any[];
   graph: { links: any[]; nodes: any[] };
   bubble: any;
+  bubble2d: any;
   linearScale: boolean = false;
   range: boolean = false;
 
@@ -281,6 +283,7 @@ export class AppComponent implements OnInit {
       graph: generateGraph(50),
       boxData,
       bubble,
+      bubble2d,
       plotData: this.generatePlotData(),
       treemap,
       bubbleDemoData,

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -782,6 +782,45 @@ const chartGroups = [
         }
       },
       {
+        name: 'Bubble Chart 2D',
+        selector: 'bubble-chart-2d',
+        inputFormat: 'bubble2d',
+        options: [
+          'animations',
+          'colorScheme',
+          'schemeType',
+          'showXAxis',
+          'showYAxis',
+          'showLegend',
+          'legendTitle',
+          'legendPosition',
+          'showXAxisLabel',
+          'xAxisLabel',
+          'showYAxisLabel',
+          'yAxisLabel',
+          'showGridLines',
+          'roundDomains',
+          'autoScale',
+          'minRadius',
+          'maxRadius',
+          'tooltipDisabled',
+          'xScaleMin',
+          'xScaleMax',
+          'yScaleMin',
+          'yScaleMax',
+          'trimXAxisTicks',
+          'trimYAxisTicks',
+          'rotateXAxisTicks',
+          'maxXAxisTickLength',
+          'maxYAxisTickLength',
+          'wrapTicks'
+        ],
+        defaults: {
+          xAxisLabel: 'Census Date',
+          yAxisLabel: 'Country'
+        }
+      },
+      {
         name: 'Equation Plots',
         selector: 'plot-demo',
         inputFormat: 'statusData',

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -318,15 +318,15 @@ export const bubble2d: BubbleChart2DMultiSeries = [
     series: [
       {
         x: '2010',
-        r: 80.4
+        r: 8.4
       },
       {
         x: '2000',
-        r: 78
+        r: 1278
       },
       {
         x: '1990',
-        r: 79
+        r: 579
       }
     ]
   },
@@ -335,11 +335,11 @@ export const bubble2d: BubbleChart2DMultiSeries = [
     series: [
       {
         x: '2010',
-        r: 310
+        r: 10
       },
       {
         x: '2000',
-        r: 283
+        r: 2783
       },
       {
         x: '1990',
@@ -356,11 +356,11 @@ export const bubble2d: BubbleChart2DMultiSeries = [
       },
       {
         x: '2000',
-        r: 59.4
+        r: 99.2
       },
       {
         x: '1990',
-        r: 56.9
+        r: 0.01
       }
     ]
   },

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -6,7 +6,8 @@ import {
   BoxChartMultiSeries,
   Series,
   TreeMapData,
-  SankeyData
+  SankeyData,
+  BubbleChart2DMultiSeries
 } from '@swimlane/ngx-charts/models/chart-data.model';
 
 export const single: SingleSeries = [
@@ -305,6 +306,77 @@ export const bubble: BubbleChartMultiSeries = [
         name: '1990',
         x: '1990',
         y: 75.7,
+        r: 57.1
+      }
+    ]
+  }
+];
+
+export const bubble2d: BubbleChart2DMultiSeries = [
+  {
+    name: 'Germany',
+    series: [
+      {
+        x: '2010',
+        r: 80.4
+      },
+      {
+        x: '2000',
+        r: 78
+      },
+      {
+        x: '1990',
+        r: 79
+      }
+    ]
+  },
+  {
+    name: 'United States',
+    series: [
+      {
+        x: '2010',
+        r: 310
+      },
+      {
+        x: '2000',
+        r: 283
+      },
+      {
+        x: '1990',
+        r: 253
+      }
+    ]
+  },
+  {
+    name: 'France',
+    series: [
+      {
+        x: '2010',
+        r: 63
+      },
+      {
+        x: '2000',
+        r: 59.4
+      },
+      {
+        x: '1990',
+        r: 56.9
+      }
+    ]
+  },
+  {
+    name: 'United Kingdom',
+    series: [
+      {
+        x: '2010',
+        r: 62.7
+      },
+      {
+        x: '2000',
+        r: 58.9
+      },
+      {
+        x: '1990',
         r: 57.1
       }
     ]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
To achieve bubble chart with group name as Y-value, the current bubble chart requires a lot of redundant information for data input. E.g. `export const bubble: BubbleChartMultiSeries = [
  {
    name: 'Germany',
    series: [
      {
        name: '2010',
        x: '2010',
        y: 'Germany',
        r: 80.4
      },
      {
        name: '2000',
        x: '2000',
        y: 'Germany',
        r: 78
      },
      {
        name: '1990',
        x: '1990',
        y: 'Germany',
        r: 79
      }
    ]
  },
`. 
In order to fix the problem, I added this new 2D bubble chart, which only requires group name, x value, and r value as data input. E.g. `  {
    name: 'Germany',
    series: [
      {
        x: '2010',
        r: 8.4
      },
      {
        x: '2000',
        r: 1278
      },
      {
        x: '1990',
        r: 579
      }
    ]
  }`

**What is the new behavior?**
![IMG_3111](https://github.com/swimlane/ngx-charts/assets/98619414/eb944595-c7fc-4d50-9256-7c64181c13b1)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
