### PR TITLE
Use a unique mask ID for each percent gauge chart

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.1.2
+
+- Fix: Percent Gauge Chart: Ensures the circle mask ID is unique for each chart
+
 ## 21.1.1
 
 - Fix: Percent Gauge Chart: Fixes server-side-rendering

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-charts",
-  "version": "21.1.1",
+  "version": "21.1.2",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",

--- a/projects/swimlane/ngx-charts/src/lib/gauge/percent-gauge/percent-gauge.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/gauge/percent-gauge/percent-gauge.component.ts
@@ -5,6 +5,7 @@ import { calculateViewDimensions } from '../../common/view-dimensions.helper';
 import { ColorHelper } from '../../common/color.helper';
 import { ViewDimensions } from '../../common/types/view-dimension.interface';
 import { ScaleType } from '../../common/types/scale-type.enum';
+import { id } from '../../utils/id';
 
 @Component({
   selector: 'ngx-charts-percent-gauge',
@@ -12,7 +13,7 @@ import { ScaleType } from '../../common/types/scale-type.enum';
     <ngx-charts-chart [view]="[width, height]" [showLegend]="false" [animations]="animations">
       <svg:g class="percent-gauge chart" (click)="onClick()">
         <svg:g [attr.transform]="transform">
-          <mask id="circleMask">
+          <mask [attr.id]="circleMaskId">
             <circle
               [attr.r]="radius"
               [style.stroke-width]="radius / 5"
@@ -38,7 +39,7 @@ import { ScaleType } from '../../common/types/scale-type.enum';
             [style.stroke-dasharray]="dashes"
           />
 
-          <svg:g mask="url(#circleMask)">
+          <svg:g [attr.mask]="'url(#' + circleMaskId + ')'">
             <svg:g [attr.transform]="circleTransform">
               <svg:g *ngFor="let tic of ticks" [attr.transform]="tic.transform">
                 <rect
@@ -125,6 +126,7 @@ export class PercentGaugeComponent extends BaseChartComponent {
   targetRadius: number;
   targetTextTransform: string;
 
+  circleMaskId: string;
   circleTransform: string;
   ticks: any[] = [];
   ticHeight: number;
@@ -141,6 +143,8 @@ export class PercentGaugeComponent extends BaseChartComponent {
 
   update(): void {
     super.update();
+
+    this.circleMaskId = `circleMask${id()}`;
 
     this.margin = [...this.defaultMargin];
     if (this.showLabel) {


### PR DESCRIPTION
- Circle masks are now unique per percent gauge chart used on the page

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
