### PR TITLE
fix: include detection of iPads in desktop mode when activating chart tooltips

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
@@ -113,9 +113,13 @@ export class TooltipDirective implements OnDestroy {
   showTooltip(immediate?: boolean): void {
     if (this.component || this.tooltipDisabled) return;
 
+    const isIosDevice =
+            navigator.userAgent.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/) ||
+            (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints && navigator.maxTouchPoints > 1);
+
     const time = immediate
       ? 0
-      : this.tooltipShowTimeout + (navigator.userAgent.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/) ? 400 : 0);
+      : isIosDevice ? 400 : 0;
 
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
Chart tooltips don't activate when using iPads set to Request Desktop Website as described in #2045 



**What is the new behavior?**
Chart tooltips will now activate when using iPads, regardless if they are in Desktop or Mobile mode.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
NO breaking changes.


**Other information**:
