### PR TITLE
fix(deps): remove unused runtime (peer) dependencies

### DIFF
--- a/projects/swimlane/ngx-charts/ng-package.json
+++ b/projects/swimlane/ngx-charts/ng-package.json
@@ -4,5 +4,5 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["d3", "gradient-path"]
+  "allowedNonPeerDependencies": ["d3"]
 }

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -53,7 +53,6 @@
     "d3-shape": "^3.2.0",
     "d3-time-format": "^4.1.0",
     "d3-transition": "^3.0.1",
-    "gradient-path": "^2.3.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -34,9 +34,7 @@
     "@angular/cdk": "19.x || 20.x || 21.x",
     "@angular/core": "19.x || 20.x || 21.x",
     "@angular/common": "19.x || 20.x || 21.x",
-    "@angular/forms": "19.x || 20.x || 21.x",
     "@angular/platform-browser": "19.x || 20.x || 21.x",
-    "@angular/platform-browser-dynamic": "19.x || 20.x || 21.x",
     "rxjs": "7.x"
   },
   "dependencies": {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Dependencies

**What is the current behavior?** (You can also link to an open issue here)

Currently, this package requires `@angular/platform-browser-dynamic`, which is deprecated. I was generally surprised to see it in my dependencies; turns out it is not used by this package, so I removed it from the list.

Apart from that, I discovered that `@angular/forms` is not used either, and `gradient-path` usage was removed in https://github.com/swimlane/ngx-charts/pull/1982

**What is the new behavior?**

The new package reduces the amount of (transitive) dependencies by 4 and peer dependencies by two.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Usage of this dependency was removed in commit 3688955f51e445f92c3fd50b3251464b90eeb808